### PR TITLE
feat(v2): add design system foundations

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -5,6 +5,7 @@ import { StatusBar } from 'expo-status-bar';
 import { useEffect, useState } from 'react';
 import { Text, useColorScheme, View } from 'react-native';
 
+import { AppThemeProvider } from '@/design-system/theme-context';
 import { ensureSQLiteBootstrapped } from '@/lib/sqlite/bootstrap';
 import { i18n } from '@/lib/localization/i18n';
 import { resolveLocalizationPreferences } from '@/lib/localization/resolution';
@@ -69,9 +70,11 @@ export default function RootLayout() {
   }
 
   return (
-    <ThemeProvider value={themeMode === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack screenOptions={{ headerShown: false }} />
-      <StatusBar style={themeMode === 'dark' ? 'light' : 'dark'} />
-    </ThemeProvider>
+    <AppThemeProvider systemScheme={scheme} themePreference={themePreference}>
+      <ThemeProvider value={themeMode === 'dark' ? DarkTheme : DefaultTheme}>
+        <Stack screenOptions={{ headerShown: false }} />
+        <StatusBar style={themeMode === 'dark' ? 'light' : 'dark'} />
+      </ThemeProvider>
+    </AppThemeProvider>
   );
 }

--- a/src/app/index.test.tsx
+++ b/src/app/index.test.tsx
@@ -1,45 +1,13 @@
-import React from 'react';
-import { Text, type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
+import { Text } from 'react-native';
 import renderer, { act } from 'react-test-renderer';
 import { describe, expect, it, jest } from '@jest/globals';
 
 import { i18n } from '@/lib/localization/i18n';
+import * as mockExpoUi from '@/components/ui/expo-ui.mock';
 
 import HomeScreen from './index';
 
-jest.mock('@/components/ui/expo-ui', () => {
-  const { Pressable, Text: RNText, TextInput: RNTextInput, View } = jest.requireActual('react-native') as typeof import('react-native');
-
-  return {
-    BottomSheet: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
-    Button: ({ children, label, variant: _variant, ...props }: { children?: React.ReactNode; label?: string; variant?: string }) => (
-      <Pressable {...props}>{children ?? <RNText>{label}</RNText>}</Pressable>
-    ),
-    Host: ({ children, colorScheme: _colorScheme, style, ...props }: { children: React.ReactNode; colorScheme?: string; style?: StyleProp<ViewStyle> }) => (
-      <View {...props} style={style}>
-        {children}
-      </View>
-    ),
-    Column: ({ children, spacing, style, ...props }: { children: React.ReactNode; spacing?: number; style?: StyleProp<ViewStyle> }) => (
-      <View {...props} style={[style, spacing != null ? { gap: spacing } : null]}>
-        {children}
-      </View>
-    ),
-    Row: ({ children, spacing, style, ...props }: { children: React.ReactNode; spacing?: number; style?: StyleProp<ViewStyle> }) => (
-      <View {...props} style={[style, spacing != null ? { gap: spacing } : null]}>
-        {children}
-      </View>
-    ),
-    Text: ({ children, textStyle, style, ...props }: { children: React.ReactNode; textStyle?: StyleProp<TextStyle>; style?: StyleProp<TextStyle> }) => (
-      <RNText {...props} style={[style, textStyle]}>
-        {children}
-      </RNText>
-    ),
-    TextInput: ({ style, textStyle, ...props }: { style?: StyleProp<ViewStyle>; textStyle?: StyleProp<TextStyle> }) => (
-      <RNTextInput {...props} style={[style, textStyle]} />
-    ),
-  };
-});
+jest.mock('@/components/ui/expo-ui', () => mockExpoUi);
 
 describe('HomeScreen', () => {
   it('renders initialized i18n copy', async () => {

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,33 +1,78 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { useState } from 'react';
 
+import { AppButton, AppColumn, AppHost, AppRow, AppSelect, AppSheet, AppText, AppTextField, AdSlot } from '@/components/ui';
+import { useAppTheme } from '@/design-system/theme-context';
 import { i18n } from '@/lib/localization/i18n';
 
 export default function HomeScreen() {
+  const theme = useAppTheme();
+  const [currency, setCurrency] = useState('BRL');
+  const [isSheetVisible, setIsSheetVisible] = useState(false);
+
+  const currencyOptions = [
+    { label: i18n.t('preferences.currencyBrl'), value: 'BRL' },
+    { label: i18n.t('preferences.currencyUsd'), value: 'USD' },
+  ];
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>{i18n.t('app.readyTitle')}</Text>
-      <Text style={styles.body}>{i18n.t('app.readyBody')}</Text>
-    </View>
+    <AppHost>
+      <AppColumn spacing={theme.space.lg} style={{ padding: theme.space.content, backgroundColor: theme.colors.surface }}>
+        <AppColumn spacing={theme.space.xs}>
+          <AppText
+            textStyle={{
+              ...theme.typography.title,
+              color: theme.colors.onSurface,
+            }}
+          >
+            {i18n.t('app.readyTitle')}
+          </AppText>
+          <AppText
+            textStyle={{
+              ...theme.typography.body,
+              color: theme.colors.muted,
+            }}
+          >
+            {i18n.t('app.designPreviewBody')}
+          </AppText>
+        </AppColumn>
+
+        <AppTextField
+          helperText={i18n.t('form.searchHelper')}
+          label={i18n.t('form.searchLabel')}
+          placeholder={i18n.t('form.searchPlaceholder')}
+        />
+
+        <AppSelect
+          helperText={i18n.t('app.readyBody')}
+          label={i18n.t('form.currencyLabel')}
+          onValueChange={setCurrency}
+          options={currencyOptions}
+          placeholder={i18n.t('preferences.currencySystem')}
+          value={currency}
+        />
+
+        <AppRow spacing={theme.space.sm}>
+          <AppButton label={i18n.t('form.openSheet')} onPress={() => setIsSheetVisible(true)} />
+          <AppButton disabled label={i18n.t('app.designPreviewTitle')} variant="secondary" />
+        </AppRow>
+
+        <AppSheet
+          onClose={() => setIsSheetVisible(false)}
+          title={i18n.t('app.designPreviewTitle')}
+          visible={isSheetVisible}
+        >
+          <AppText
+            textStyle={{
+              ...theme.typography.body,
+              color: theme.colors.onSurface,
+            }}
+          >
+            {i18n.t('app.designPreviewBody')}
+          </AppText>
+        </AppSheet>
+
+        <AdSlot />
+      </AppColumn>
+    </AppHost>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 12,
-    padding: 24,
-    backgroundColor: '#FFFFFF',
-  },
-  title: {
-    color: '#172B4D',
-    fontSize: 24,
-    fontWeight: '700',
-  },
-  body: {
-    color: '#44546F',
-    fontSize: 16,
-    textAlign: 'center',
-  },
-});

--- a/src/app/theme-smoke.test.tsx
+++ b/src/app/theme-smoke.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { Text, type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
+import renderer, { act } from 'react-test-renderer';
+import { describe, expect, it, jest } from '@jest/globals';
+
+import type { ThemeMode, ThemePreference } from '@/stores/theme-preferences';
+
+import { AppThemeProvider } from '@/design-system/theme-context';
+
+import HomeScreen from './index';
+
+jest.mock('@/components/ui/expo-ui', () => {
+  const { Pressable, Text: RNText, TextInput: RNTextInput, View: RNView } = jest.requireActual('react-native') as typeof import('react-native');
+
+  return {
+    BottomSheet: ({ children }: { children: React.ReactNode }) => <RNView>{children}</RNView>,
+    Button: ({ children, label, variant: _variant, ...props }: { children?: React.ReactNode; label?: string; variant?: string }) => (
+      <Pressable {...props}>{children ?? <RNText>{label}</RNText>}</Pressable>
+    ),
+    Column: ({
+      children,
+      spacing,
+      style,
+      ...props
+    }: {
+      children: React.ReactNode;
+      spacing?: number;
+      style?: StyleProp<ViewStyle>;
+    }) => (
+      <RNView {...props} style={[style, spacing != null ? { gap: spacing } : null]}>
+        {children}
+      </RNView>
+    ),
+    Row: ({
+      children,
+      spacing,
+      style,
+      ...props
+    }: {
+      children: React.ReactNode;
+      spacing?: number;
+      style?: StyleProp<ViewStyle>;
+    }) => (
+      <RNView {...props} style={[style, spacing != null ? { gap: spacing } : null]}>
+        {children}
+      </RNView>
+    ),
+    Text: ({
+      children,
+      textStyle,
+      style,
+      ...props
+    }: {
+      children: React.ReactNode;
+      textStyle?: StyleProp<TextStyle>;
+      style?: StyleProp<TextStyle>;
+    }) => (
+      <RNText {...props} style={[style, textStyle]}>
+        {children}
+      </RNText>
+    ),
+    Host: ({
+      children,
+      colorScheme: _colorScheme,
+      style,
+      ...props
+    }: {
+      children: React.ReactNode;
+      colorScheme?: string;
+      style?: StyleProp<ViewStyle>;
+    }) => <RNView {...props} style={style}>{children}</RNView>,
+    TextInput: ({ style, textStyle, ...props }: { style?: StyleProp<ViewStyle>; textStyle?: StyleProp<TextStyle> }) => (
+      <RNTextInput {...props} style={[style, textStyle]} />
+    ),
+  };
+});
+
+describe('HomeScreen theme smoke', () => {
+  const themeCases: [string, ThemePreference, ThemeMode, ThemeMode][] = [
+    ['system light', 'system', 'light', 'light'],
+    ['system dark', 'system', 'dark', 'dark'],
+    ['light override', 'light', 'dark', 'light'],
+    ['dark override', 'dark', 'light', 'dark'],
+  ];
+
+  it.each(themeCases)('resolves %s to the expected host color scheme', (label, themePreference, systemScheme, expected) => {
+    void label;
+
+    let tree: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(
+        <AppThemeProvider systemScheme={systemScheme} themePreference={themePreference}>
+          <HomeScreen />
+        </AppThemeProvider>
+      );
+    });
+
+    expect(tree!.root.findByProps({ colorScheme: expected })).toBeTruthy();
+    expect(tree!.root.findAllByType(Text).map((node) => node.props.children)).toContain(
+      'Expo foundation ready'
+    );
+  });
+});

--- a/src/app/theme-smoke.test.tsx
+++ b/src/app/theme-smoke.test.tsx
@@ -1,79 +1,15 @@
-import React from 'react';
-import { Text, type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
+import { Text } from 'react-native';
 import renderer, { act } from 'react-test-renderer';
 import { describe, expect, it, jest } from '@jest/globals';
 
 import type { ThemeMode, ThemePreference } from '@/stores/theme-preferences';
 
 import { AppThemeProvider } from '@/design-system/theme-context';
+import * as mockExpoUi from '@/components/ui/expo-ui.mock';
 
 import HomeScreen from './index';
 
-jest.mock('@/components/ui/expo-ui', () => {
-  const { Pressable, Text: RNText, TextInput: RNTextInput, View: RNView } = jest.requireActual('react-native') as typeof import('react-native');
-
-  return {
-    BottomSheet: ({ children }: { children: React.ReactNode }) => <RNView>{children}</RNView>,
-    Button: ({ children, label, variant: _variant, ...props }: { children?: React.ReactNode; label?: string; variant?: string }) => (
-      <Pressable {...props}>{children ?? <RNText>{label}</RNText>}</Pressable>
-    ),
-    Column: ({
-      children,
-      spacing,
-      style,
-      ...props
-    }: {
-      children: React.ReactNode;
-      spacing?: number;
-      style?: StyleProp<ViewStyle>;
-    }) => (
-      <RNView {...props} style={[style, spacing != null ? { gap: spacing } : null]}>
-        {children}
-      </RNView>
-    ),
-    Row: ({
-      children,
-      spacing,
-      style,
-      ...props
-    }: {
-      children: React.ReactNode;
-      spacing?: number;
-      style?: StyleProp<ViewStyle>;
-    }) => (
-      <RNView {...props} style={[style, spacing != null ? { gap: spacing } : null]}>
-        {children}
-      </RNView>
-    ),
-    Text: ({
-      children,
-      textStyle,
-      style,
-      ...props
-    }: {
-      children: React.ReactNode;
-      textStyle?: StyleProp<TextStyle>;
-      style?: StyleProp<TextStyle>;
-    }) => (
-      <RNText {...props} style={[style, textStyle]}>
-        {children}
-      </RNText>
-    ),
-    Host: ({
-      children,
-      colorScheme: _colorScheme,
-      style,
-      ...props
-    }: {
-      children: React.ReactNode;
-      colorScheme?: string;
-      style?: StyleProp<ViewStyle>;
-    }) => <RNView {...props} style={style}>{children}</RNView>,
-    TextInput: ({ style, textStyle, ...props }: { style?: StyleProp<ViewStyle>; textStyle?: StyleProp<TextStyle> }) => (
-      <RNTextInput {...props} style={[style, textStyle]} />
-    ),
-  };
-});
+jest.mock('@/components/ui/expo-ui', () => mockExpoUi);
 
 describe('HomeScreen theme smoke', () => {
   const themeCases: [string, ThemePreference, ThemeMode, ThemeMode][] = [

--- a/src/components/ui/ad-slot.android.tsx
+++ b/src/components/ui/ad-slot.android.tsx
@@ -1,0 +1,10 @@
+import { View } from 'react-native';
+
+export type AdSlotProps = {
+  testID?: string;
+};
+
+export function AdSlot({ testID }: AdSlotProps) {
+  // Native ad placement stays isolated here until the release gate enables AdMob wiring.
+  return <View accessibilityLabel="Native ad slot reserved" collapsable={false} testID={testID} />;
+}

--- a/src/components/ui/ad-slot.ios.tsx
+++ b/src/components/ui/ad-slot.ios.tsx
@@ -1,0 +1,10 @@
+import { View } from 'react-native';
+
+export type AdSlotProps = {
+  testID?: string;
+};
+
+export function AdSlot({ testID }: AdSlotProps) {
+  // Native ad placement stays isolated here until the release gate enables AdMob wiring.
+  return <View accessibilityLabel="Native ad slot reserved" collapsable={false} testID={testID} />;
+}

--- a/src/components/ui/ad-slot.tsx
+++ b/src/components/ui/ad-slot.tsx
@@ -1,0 +1,7 @@
+export type AdSlotProps = {
+  testID?: string;
+};
+
+export function AdSlot(_: AdSlotProps) {
+  return null;
+}

--- a/src/components/ui/adapters.test.tsx
+++ b/src/components/ui/adapters.test.tsx
@@ -1,39 +1,13 @@
-import { Text, View, type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
+import { Text, View } from 'react-native';
 import renderer, { act } from 'react-test-renderer';
 import { describe, expect, it, jest } from '@jest/globals';
 
 import { AppThemeProvider } from '@/design-system/theme-context';
 
+import * as mockExpoUi from './expo-ui.mock';
 import { AdSlot, AppButton, AppSelect, AppSheet, AppTextField } from './index';
 
-jest.mock('./expo-ui', () => {
-  const { Pressable, Text: RNText, TextInput: RNTextInput, View } = jest.requireActual('react-native') as typeof import('react-native');
-
-  return {
-    BottomSheet: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
-    Button: ({ children, label, variant: _variant, ...props }: { children?: React.ReactNode; label?: string; variant?: string }) => (
-      <Pressable {...props}>{children ?? <RNText>{label}</RNText>}</Pressable>
-    ),
-    Column: ({ children, spacing, style, ...props }: { children: React.ReactNode; spacing?: number; style?: StyleProp<ViewStyle> }) => (
-      <View {...props} style={[style, spacing != null ? { gap: spacing } : null]}>
-        {children}
-      </View>
-    ),
-    Row: ({ children, spacing, style, ...props }: { children: React.ReactNode; spacing?: number; style?: StyleProp<ViewStyle> }) => (
-      <View {...props} style={[style, spacing != null ? { gap: spacing } : null]}>
-        {children}
-      </View>
-    ),
-    Text: ({ children, textStyle, style, ...props }: { children: React.ReactNode; textStyle?: StyleProp<TextStyle>; style?: StyleProp<TextStyle> }) => (
-      <RNText {...props} style={[style, textStyle]}>
-        {children}
-      </RNText>
-    ),
-    TextInput: ({ style, textStyle, ...props }: { style?: StyleProp<ViewStyle>; textStyle?: StyleProp<TextStyle> }) => (
-      <RNTextInput {...props} style={[style, textStyle]} />
-    ),
-  };
-});
+jest.mock('./expo-ui', () => mockExpoUi);
 
 describe('universal adapters', () => {
   it('renders the button, field, select, sheet, and ad slot boundaries', () => {

--- a/src/components/ui/adapters.test.tsx
+++ b/src/components/ui/adapters.test.tsx
@@ -1,24 +1,18 @@
-import React from 'react';
-import { Text, type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
+import { Text, View, type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
 import renderer, { act } from 'react-test-renderer';
 import { describe, expect, it, jest } from '@jest/globals';
 
-import { i18n } from '@/lib/localization/i18n';
+import { AppThemeProvider } from '@/design-system/theme-context';
 
-import HomeScreen from './index';
+import { AdSlot, AppButton, AppSelect, AppSheet, AppTextField } from './index';
 
-jest.mock('@/components/ui/expo-ui', () => {
+jest.mock('./expo-ui', () => {
   const { Pressable, Text: RNText, TextInput: RNTextInput, View } = jest.requireActual('react-native') as typeof import('react-native');
 
   return {
     BottomSheet: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
     Button: ({ children, label, variant: _variant, ...props }: { children?: React.ReactNode; label?: string; variant?: string }) => (
       <Pressable {...props}>{children ?? <RNText>{label}</RNText>}</Pressable>
-    ),
-    Host: ({ children, colorScheme: _colorScheme, style, ...props }: { children: React.ReactNode; colorScheme?: string; style?: StyleProp<ViewStyle> }) => (
-      <View {...props} style={style}>
-        {children}
-      </View>
     ),
     Column: ({ children, spacing, style, ...props }: { children: React.ReactNode; spacing?: number; style?: StyleProp<ViewStyle> }) => (
       <View {...props} style={[style, spacing != null ? { gap: spacing } : null]}>
@@ -41,38 +35,37 @@ jest.mock('@/components/ui/expo-ui', () => {
   };
 });
 
-describe('HomeScreen', () => {
-  it('renders initialized i18n copy', async () => {
-    await i18n.changeLanguage('en');
-
+describe('universal adapters', () => {
+  it('renders the button, field, select, sheet, and ad slot boundaries', () => {
     let tree: renderer.ReactTestRenderer;
 
-    await act(async () => {
-      tree = renderer.create(<HomeScreen />);
+    act(() => {
+      tree = renderer.create(
+        <AppThemeProvider systemScheme="light" themePreference="system">
+          <View>
+            <AppButton label="Confirm" onPress={() => undefined} />
+            <AppTextField label="Search" helperText="Semantic tokens" placeholder="Type here" />
+            <AppSelect
+              label="Currency"
+              onValueChange={() => undefined}
+              options={[{ label: 'Brazilian real', value: 'BRL' }]}
+              placeholder="Choose"
+              value="BRL"
+            />
+            <AppSheet visible={false} onClose={() => undefined} title="Sheet">
+              <Text>Content</Text>
+            </AppSheet>
+            <AdSlot />
+          </View>
+        </AppThemeProvider>
+      );
     });
 
     const texts = tree!.root.findAllByType(Text).map((node) => node.props.children);
 
-    expect(texts).toContain('Expo foundation ready');
-    expect(texts).toContain('Semantic tokens, adapters, and theme resolution are wired up.');
-    expect(texts).toContain('Router, SQLite, and preferences are initialized.');
-    expect(texts).toContain('Open sheet');
-  });
-
-  it('renders the home placeholder copy', async () => {
-    await i18n.changeLanguage('pt-BR');
-
-    let tree: renderer.ReactTestRenderer;
-
-    await act(async () => {
-      tree = renderer.create(<HomeScreen />);
-    });
-
-    const texts = tree!.root.findAllByType(Text).map((node) => node.props.children);
-
-    expect(texts).toContain('Base do Expo pronta');
-    expect(texts).toContain('Tokens semânticos, adapters e resolução de tema já estão conectados.');
-    expect(texts).toContain('Router, SQLite e preferências estão inicializados.');
-    expect(texts).toContain('Abrir painel');
+    expect(texts).toContain('Confirm');
+    expect(texts).toContain('Search');
+    expect(texts).toContain('Currency');
+    expect(texts).toContain('Semantic tokens');
   });
 });

--- a/src/components/ui/app-button.tsx
+++ b/src/components/ui/app-button.tsx
@@ -1,0 +1,46 @@
+import type { ComponentPropsWithoutRef } from 'react';
+import { StyleSheet, type AccessibilityProps, type StyleProp, type ViewStyle } from 'react-native';
+
+import { useAppTheme } from '@/design-system/theme-context';
+
+import { Button } from './expo-ui';
+
+type AppButtonVariant = 'primary' | 'secondary' | 'ghost';
+
+type ExpoButtonProps = ComponentPropsWithoutRef<typeof Button>;
+
+export type AppButtonProps = Omit<ExpoButtonProps, 'children' | 'label' | 'style' | 'variant'> & {
+  label: string;
+  style?: StyleProp<ViewStyle>;
+  variant?: AppButtonVariant;
+} & Pick<AccessibilityProps, 'accessibilityLabel' | 'accessibilityValue'>;
+
+export function AppButton({ disabled, label, style, variant = 'primary', ...props }: AppButtonProps) {
+  const theme = useAppTheme();
+  const buttonStyle = {
+    borderRadius: theme.radius.pill,
+    paddingHorizontal: theme.space.md,
+    paddingVertical: theme.space.sm,
+    ...(variant === 'primary' ? { backgroundColor: theme.colors.focus } : {}),
+    ...(variant === 'secondary'
+      ? {
+          backgroundColor: theme.colors.surfaceRaised,
+          borderColor: theme.colors.border,
+          borderWidth: 1,
+        }
+      : {}),
+    ...(variant === 'ghost' ? { backgroundColor: 'transparent' } : {}),
+    ...(disabled ? { opacity: 0.55 } : {}),
+    ...(StyleSheet.flatten(style) ?? {}),
+  };
+
+  return (
+    <Button
+      disabled={disabled}
+      label={label}
+      style={buttonStyle}
+      variant={variant === 'primary' ? 'filled' : variant === 'secondary' ? 'outlined' : 'text'}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/app-column.tsx
+++ b/src/components/ui/app-column.tsx
@@ -1,0 +1,11 @@
+import type { ComponentPropsWithoutRef } from 'react';
+
+import { Column } from './expo-ui';
+
+type ExpoColumnProps = ComponentPropsWithoutRef<typeof Column>;
+
+export type AppColumnProps = ExpoColumnProps;
+
+export function AppColumn(props: AppColumnProps) {
+  return <Column {...props} />;
+}

--- a/src/components/ui/app-host.test.tsx
+++ b/src/components/ui/app-host.test.tsx
@@ -1,28 +1,13 @@
-import React from 'react';
-import { View, type StyleProp, type ViewStyle } from 'react-native';
+import { View } from 'react-native';
 import renderer, { act } from 'react-test-renderer';
 import { describe, expect, it, jest } from '@jest/globals';
 
 import { AppThemeProvider } from '@/design-system/theme-context';
 
+import * as mockExpoUi from './expo-ui.mock';
 import { AppHost } from './app-host';
 
-jest.mock('./expo-ui', () => ({
-  Host: ({
-    children,
-    colorScheme: _colorScheme,
-    style,
-    ...props
-  }: {
-    children: React.ReactNode;
-    colorScheme?: string;
-    style?: StyleProp<ViewStyle>;
-  }) => {
-    const { View: RNView } = jest.requireActual('react-native') as typeof import('react-native');
-
-    return <RNView {...props} style={style}>{children}</RNView>;
-  },
-}));
+jest.mock('./expo-ui', () => mockExpoUi);
 
 describe('AppHost', () => {
   it('maps the resolved semantic mode to the @expo/ui Host boundary', () => {

--- a/src/components/ui/app-host.test.tsx
+++ b/src/components/ui/app-host.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { View, type StyleProp, type ViewStyle } from 'react-native';
+import renderer, { act } from 'react-test-renderer';
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { AppThemeProvider } from '@/design-system/theme-context';
+
+import { AppHost } from './app-host';
+
+jest.mock('./expo-ui', () => ({
+  Host: ({
+    children,
+    colorScheme: _colorScheme,
+    style,
+    ...props
+  }: {
+    children: React.ReactNode;
+    colorScheme?: string;
+    style?: StyleProp<ViewStyle>;
+  }) => {
+    const { View: RNView } = jest.requireActual('react-native') as typeof import('react-native');
+
+    return <RNView {...props} style={style}>{children}</RNView>;
+  },
+}));
+
+describe('AppHost', () => {
+  it('maps the resolved semantic mode to the @expo/ui Host boundary', () => {
+    let tree: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(
+        <AppThemeProvider systemScheme="dark" themePreference="system">
+          <AppHost>
+            <View testID="child" />
+          </AppHost>
+        </AppThemeProvider>
+      );
+    });
+
+    const host = tree!.root.findByProps({ colorScheme: 'dark' });
+
+    expect(host).toBeTruthy();
+    expect(host.findByProps({ testID: 'child' })).toBeTruthy();
+  });
+});

--- a/src/components/ui/app-host.tsx
+++ b/src/components/ui/app-host.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+import { StyleSheet } from 'react-native';
+
+import { useAppTheme } from '@/design-system/theme-context';
+
+import { Host } from './expo-ui';
+
+type AppHostProps = {
+  children: ReactNode;
+};
+
+export function AppHost({ children }: AppHostProps) {
+  const theme = useAppTheme();
+
+  return (
+    <Host colorScheme={theme.mode} style={[styles.host, { backgroundColor: theme.colors.surface }]}>
+      {children}
+    </Host>
+  );
+}
+
+const styles = StyleSheet.create({
+  host: {
+    flex: 1,
+  },
+});

--- a/src/components/ui/app-row.tsx
+++ b/src/components/ui/app-row.tsx
@@ -1,0 +1,11 @@
+import type { ComponentPropsWithoutRef } from 'react';
+
+import { Row } from './expo-ui';
+
+type ExpoRowProps = ComponentPropsWithoutRef<typeof Row>;
+
+export type AppRowProps = ExpoRowProps;
+
+export function AppRow(props: AppRowProps) {
+  return <Row {...props} />;
+}

--- a/src/components/ui/app-select.test.tsx
+++ b/src/components/ui/app-select.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
+import renderer, { act } from 'react-test-renderer';
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { AppThemeProvider } from '@/design-system/theme-context';
+import { BottomSheet, Button } from './expo-ui';
+import { AppSelect } from './app-select';
+
+jest.mock('./expo-ui', () => {
+  const { Pressable: RNPressable, Text: RNText, View: RNView } = jest.requireActual('react-native') as typeof import('react-native');
+
+  return {
+    BottomSheet: ({ children }: { children: React.ReactNode }) => <RNView>{children}</RNView>,
+    Button: ({ children, label, variant: _variant, ...props }: { children?: React.ReactNode; label?: string; variant?: string }) => (
+      <RNPressable {...props}>{children ?? <RNText>{label}</RNText>}</RNPressable>
+    ),
+    Column: ({ children, spacing, style, ...props }: { children: React.ReactNode; spacing?: number; style?: StyleProp<ViewStyle> }) => (
+      <RNView {...props} style={[style, spacing != null ? { gap: spacing } : null]}>
+        {children}
+      </RNView>
+    ),
+    Text: ({ children, textStyle, style, ...props }: { children: React.ReactNode; textStyle?: StyleProp<TextStyle>; style?: StyleProp<TextStyle> }) => (
+      <RNText {...props} style={[style, textStyle]}>
+        {children}
+      </RNText>
+    ),
+  };
+});
+
+describe('AppSelect', () => {
+  it('marks selection and disabled state accessibly', () => {
+    const onValueChange = jest.fn();
+
+    let tree: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(
+        <AppThemeProvider systemScheme="light" themePreference="system">
+          <AppSelect
+            label="Currency"
+            onValueChange={onValueChange}
+            options={[
+              { label: 'Brazilian real', value: 'BRL' },
+              { label: 'US dollar', value: 'USD', disabled: true },
+            ]}
+            value="BRL"
+          />
+        </AppThemeProvider>
+      );
+    });
+
+    act(() => {
+      tree!.root.findByType(Button).props.onPress();
+    });
+
+    const bottomSheet = tree!.root.findByType(BottomSheet);
+    const triggerButton = tree!.root.findByType(Button);
+    const selectedOption = tree!.root.findByProps({ testID: 'app-select-option-BRL' });
+    const disabledOption = tree!.root.findByProps({ testID: 'app-select-option-USD' });
+
+    expect(bottomSheet.props.isPresented).toBe(true);
+    expect(triggerButton.props.accessibilityLabel).toBe('Currency');
+    expect(triggerButton.props.accessibilityValue).toEqual({ text: 'Brazilian real' });
+    expect(selectedOption.props.accessibilityRole).toBe('radio');
+    expect(selectedOption.props.accessibilityState).toEqual({ checked: true, disabled: false });
+    expect(disabledOption.props.accessibilityState).toEqual({ checked: false, disabled: true });
+
+    act(() => {
+      disabledOption.props.onPress();
+    });
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(bottomSheet.props.isPresented).toBe(true);
+  });
+});

--- a/src/components/ui/app-select.test.tsx
+++ b/src/components/ui/app-select.test.tsx
@@ -1,32 +1,12 @@
-import React from 'react';
-import { type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
 import renderer, { act } from 'react-test-renderer';
 import { describe, expect, it, jest } from '@jest/globals';
 
 import { AppThemeProvider } from '@/design-system/theme-context';
+import * as mockExpoUi from './expo-ui.mock';
 import { BottomSheet, Button } from './expo-ui';
 import { AppSelect } from './app-select';
 
-jest.mock('./expo-ui', () => {
-  const { Pressable: RNPressable, Text: RNText, View: RNView } = jest.requireActual('react-native') as typeof import('react-native');
-
-  return {
-    BottomSheet: ({ children }: { children: React.ReactNode }) => <RNView>{children}</RNView>,
-    Button: ({ children, label, variant: _variant, ...props }: { children?: React.ReactNode; label?: string; variant?: string }) => (
-      <RNPressable {...props}>{children ?? <RNText>{label}</RNText>}</RNPressable>
-    ),
-    Column: ({ children, spacing, style, ...props }: { children: React.ReactNode; spacing?: number; style?: StyleProp<ViewStyle> }) => (
-      <RNView {...props} style={[style, spacing != null ? { gap: spacing } : null]}>
-        {children}
-      </RNView>
-    ),
-    Text: ({ children, textStyle, style, ...props }: { children: React.ReactNode; textStyle?: StyleProp<TextStyle>; style?: StyleProp<TextStyle> }) => (
-      <RNText {...props} style={[style, textStyle]}>
-        {children}
-      </RNText>
-    ),
-  };
-});
+jest.mock('./expo-ui', () => mockExpoUi);
 
 describe('AppSelect', () => {
   it('marks selection and disabled state accessibly', () => {

--- a/src/components/ui/app-select.tsx
+++ b/src/components/ui/app-select.tsx
@@ -1,0 +1,132 @@
+import { useState } from 'react';
+import { Pressable } from 'react-native';
+
+import { useAppTheme } from '@/design-system/theme-context';
+
+import { AppButton } from './app-button';
+import { AppSheet } from './app-sheet';
+import { Column, Text } from './expo-ui';
+
+export type AppSelectOption = {
+  label: string;
+  value: string;
+  disabled?: boolean;
+};
+
+export type AppSelectProps = {
+  helperText?: string;
+  label: string;
+  onValueChange: (value: string) => void;
+  options: readonly AppSelectOption[];
+  placeholder?: string;
+  testID?: string;
+  value: string | null | undefined;
+};
+
+export function AppSelect({ helperText, label, onValueChange, options, placeholder, testID, value }: AppSelectProps) {
+  const theme = useAppTheme();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const selectedOption = options.find((option) => option.value === value) ?? null;
+  const triggerLabel = selectedOption?.label ?? placeholder ?? label;
+
+  return (
+    <Column spacing={theme.space.xs} style={styles.container}>
+      <Text
+        textStyle={{
+          color: theme.colors.onSurface,
+          fontSize: theme.typography.label.fontSize,
+          fontWeight: theme.typography.label.fontWeight,
+          lineHeight: theme.typography.label.lineHeight,
+        }}
+      >
+        {label}
+      </Text>
+      <AppButton
+        accessibilityLabel={label}
+        accessibilityValue={{ text: triggerLabel }}
+        label={triggerLabel}
+        onPress={() => setIsOpen(true)}
+        style={{
+          backgroundColor: theme.colors.surfaceRaised,
+          borderColor: theme.colors.border,
+          borderWidth: 1,
+        }}
+        testID={testID}
+        variant="secondary"
+      />
+      {helperText ? (
+        <Text
+          textStyle={{
+            color: theme.colors.muted,
+            fontSize: theme.typography.body.fontSize,
+            fontWeight: theme.typography.body.fontWeight,
+            lineHeight: theme.typography.body.lineHeight,
+          }}
+        >
+          {helperText}
+        </Text>
+      ) : null}
+
+      <AppSheet onClose={() => setIsOpen(false)} title={label} visible={isOpen}>
+        <Column spacing={theme.space.sm}>
+          {options.map((option) => {
+            const isSelected = option.value === value;
+
+            return (
+              <Pressable
+                accessibilityLabel={option.label}
+                accessibilityRole="radio"
+                accessibilityState={{ checked: isSelected, disabled: option.disabled ?? false }}
+                disabled={option.disabled}
+                key={option.value}
+                onPress={() => {
+                  if (option.disabled) {
+                    return;
+                  }
+
+                  onValueChange(option.value);
+                  setIsOpen(false);
+                }}
+                style={[
+                  styles.option,
+                  {
+                    backgroundColor: isSelected ? theme.colors.backgroundSelected : theme.colors.surface,
+                    borderColor: theme.colors.border,
+                    opacity: option.disabled ? 0.5 : 1,
+                    paddingHorizontal: theme.space.md,
+                    paddingVertical: theme.space.sm,
+                  },
+                ]}
+                testID={`app-select-option-${option.value}`}
+              >
+                <Text
+                  textStyle={{
+                    color: theme.colors.onSurface,
+                    fontSize: theme.typography.body.fontSize,
+                    fontWeight: isSelected ? '700' : '500',
+                    lineHeight: theme.typography.body.lineHeight,
+                  }}
+                >
+                  {option.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </Column>
+      </AppSheet>
+    </Column>
+  );
+}
+
+const styles = {
+  container: {
+    width: '100%',
+  },
+  option: {
+    borderRadius: 12,
+    borderWidth: 1,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+} as const;

--- a/src/components/ui/app-sheet.test.tsx
+++ b/src/components/ui/app-sheet.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { View, type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
+import renderer, { act } from 'react-test-renderer';
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { AppThemeProvider } from '@/design-system/theme-context';
+import { BottomSheet } from './expo-ui';
+import { AppSheet } from './app-sheet';
+
+jest.mock('./expo-ui', () => {
+  const { Text: RNText, View: RNView } = jest.requireActual('react-native') as typeof import('react-native');
+
+  return {
+    BottomSheet: ({ children }: { children: React.ReactNode }) => <RNView>{children}</RNView>,
+    Column: ({ children, spacing, style, ...props }: { children: React.ReactNode; spacing?: number; style?: StyleProp<ViewStyle> }) => (
+      <RNView {...props} style={[style, spacing != null ? { gap: spacing } : null]}>
+        {children}
+      </RNView>
+    ),
+    Text: ({ children, textStyle, style, ...props }: { children: React.ReactNode; textStyle?: StyleProp<TextStyle>; style?: StyleProp<TextStyle> }) => (
+      <RNText {...props} style={[style, textStyle]}>
+        {children}
+      </RNText>
+    ),
+  };
+});
+
+describe('AppSheet', () => {
+  it('dismisses through the bottom-sheet callback', () => {
+    const onClose = jest.fn();
+
+    let tree: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(
+        <AppThemeProvider systemScheme="light" themePreference="system">
+          <AppSheet onClose={onClose} title="Sheet" visible>
+            <View />
+          </AppSheet>
+        </AppThemeProvider>
+      );
+    });
+
+    tree!.root.findByType(BottomSheet).props.onDismiss();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ui/app-sheet.test.tsx
+++ b/src/components/ui/app-sheet.test.tsx
@@ -1,29 +1,13 @@
-import React from 'react';
-import { View, type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
+import { View } from 'react-native';
 import renderer, { act } from 'react-test-renderer';
 import { describe, expect, it, jest } from '@jest/globals';
 
 import { AppThemeProvider } from '@/design-system/theme-context';
+import * as mockExpoUi from './expo-ui.mock';
 import { BottomSheet } from './expo-ui';
 import { AppSheet } from './app-sheet';
 
-jest.mock('./expo-ui', () => {
-  const { Text: RNText, View: RNView } = jest.requireActual('react-native') as typeof import('react-native');
-
-  return {
-    BottomSheet: ({ children }: { children: React.ReactNode }) => <RNView>{children}</RNView>,
-    Column: ({ children, spacing, style, ...props }: { children: React.ReactNode; spacing?: number; style?: StyleProp<ViewStyle> }) => (
-      <RNView {...props} style={[style, spacing != null ? { gap: spacing } : null]}>
-        {children}
-      </RNView>
-    ),
-    Text: ({ children, textStyle, style, ...props }: { children: React.ReactNode; textStyle?: StyleProp<TextStyle>; style?: StyleProp<TextStyle> }) => (
-      <RNText {...props} style={[style, textStyle]}>
-        {children}
-      </RNText>
-    ),
-  };
-});
+jest.mock('./expo-ui', () => mockExpoUi);
 
 describe('AppSheet', () => {
   it('dismisses through the bottom-sheet callback', () => {

--- a/src/components/ui/app-sheet.tsx
+++ b/src/components/ui/app-sheet.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from 'react';
+import { useAppTheme } from '@/design-system/theme-context';
+
+import { BottomSheet, Column, Text } from './expo-ui';
+
+type AppSheetProps = {
+  children: ReactNode;
+  onClose: () => void;
+  title?: string;
+  visible: boolean;
+};
+
+export function AppSheet({ children, onClose, title, visible }: AppSheetProps) {
+  const theme = useAppTheme();
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <BottomSheet isPresented={visible} onDismiss={onClose} testID="app-sheet">
+      <Column
+        spacing={theme.space.md}
+        style={{
+          ...styles.sheet,
+          backgroundColor: theme.colors.surfaceRaised,
+          borderColor: theme.colors.border,
+          padding: theme.space.lg,
+        }}
+      >
+        {title ? (
+          <Text
+            textStyle={{
+              color: theme.colors.onSurface,
+              fontSize: theme.typography.title.fontSize,
+              fontWeight: theme.typography.title.fontWeight,
+              lineHeight: theme.typography.title.lineHeight,
+            }}
+          >
+            {title}
+          </Text>
+        ) : null}
+        {children}
+      </Column>
+    </BottomSheet>
+  );
+}
+
+const styles = {
+  sheet: {
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    borderWidth: 1,
+  },
+} as const;

--- a/src/components/ui/app-text-field.test.tsx
+++ b/src/components/ui/app-text-field.test.tsx
@@ -1,31 +1,12 @@
-import React from 'react';
-import { type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
 import renderer, { act } from 'react-test-renderer';
 import { describe, expect, it, jest } from '@jest/globals';
 
 import { AppThemeProvider } from '@/design-system/theme-context';
+import * as mockExpoUi from './expo-ui.mock';
 import { TextInput } from './expo-ui';
 import { AppTextField } from './app-text-field';
 
-jest.mock('./expo-ui', () => {
-  const { Text: RNText, TextInput: RNTextInput, View: RNView } = jest.requireActual('react-native') as typeof import('react-native');
-
-  return {
-    Column: ({ children, spacing, style, ...props }: { children: React.ReactNode; spacing?: number; style?: StyleProp<ViewStyle> }) => (
-      <RNView {...props} style={[style, spacing != null ? { gap: spacing } : null]}>
-        {children}
-      </RNView>
-    ),
-    Text: ({ children, textStyle, style, ...props }: { children: React.ReactNode; textStyle?: StyleProp<TextStyle>; style?: StyleProp<TextStyle> }) => (
-      <RNText {...props} style={[style, textStyle]}>
-        {children}
-      </RNText>
-    ),
-    TextInput: ({ style, textStyle, ...props }: { style?: StyleProp<ViewStyle>; textStyle?: StyleProp<TextStyle> }) => (
-      <RNTextInput {...props} style={[style, textStyle]} />
-    ),
-  };
-});
+jest.mock('./expo-ui', () => mockExpoUi);
 
 describe('AppTextField', () => {
   it('updates the border color when focused and blurred', () => {

--- a/src/components/ui/app-text-field.test.tsx
+++ b/src/components/ui/app-text-field.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
+import renderer, { act } from 'react-test-renderer';
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { AppThemeProvider } from '@/design-system/theme-context';
+import { TextInput } from './expo-ui';
+import { AppTextField } from './app-text-field';
+
+jest.mock('./expo-ui', () => {
+  const { Text: RNText, TextInput: RNTextInput, View: RNView } = jest.requireActual('react-native') as typeof import('react-native');
+
+  return {
+    Column: ({ children, spacing, style, ...props }: { children: React.ReactNode; spacing?: number; style?: StyleProp<ViewStyle> }) => (
+      <RNView {...props} style={[style, spacing != null ? { gap: spacing } : null]}>
+        {children}
+      </RNView>
+    ),
+    Text: ({ children, textStyle, style, ...props }: { children: React.ReactNode; textStyle?: StyleProp<TextStyle>; style?: StyleProp<TextStyle> }) => (
+      <RNText {...props} style={[style, textStyle]}>
+        {children}
+      </RNText>
+    ),
+    TextInput: ({ style, textStyle, ...props }: { style?: StyleProp<ViewStyle>; textStyle?: StyleProp<TextStyle> }) => (
+      <RNTextInput {...props} style={[style, textStyle]} />
+    ),
+  };
+});
+
+describe('AppTextField', () => {
+  it('updates the border color when focused and blurred', () => {
+    const onBlur = jest.fn();
+    const onFocus = jest.fn();
+
+    let tree: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(
+        <AppThemeProvider systemScheme="light" themePreference="system">
+          <AppTextField label="Search" onBlur={onBlur} onFocus={onFocus} placeholder="Type here" />
+        </AppThemeProvider>
+      );
+    });
+
+    const input = () => tree!.root.findByType(TextInput);
+
+    expect(input().props.accessibilityLabel).toBe('Search');
+    expect(input().props.style.borderColor).toBe('#D7DFEA');
+
+    act(() => {
+      input().props.onFocus?.({ nativeEvent: { target: 1 } });
+    });
+
+    expect(input().props.style.borderColor).toBe('#208AEF');
+    expect(onFocus).toHaveBeenCalledWith({ nativeEvent: { target: 1 } });
+
+    act(() => {
+      input().props.onBlur?.({ nativeEvent: { target: 2 } });
+    });
+
+    expect(input().props.style.borderColor).toBe('#D7DFEA');
+    expect(onBlur).toHaveBeenCalledWith({ nativeEvent: { target: 2 } });
+  });
+});

--- a/src/components/ui/app-text-field.tsx
+++ b/src/components/ui/app-text-field.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import type { ComponentPropsWithoutRef, ComponentType } from 'react';
+import {
+  StyleSheet,
+  type NativeSyntheticEvent,
+  type TextInputFocusEventData,
+  type TextStyle,
+} from 'react-native';
+
+import { useAppTheme } from '@/design-system/theme-context';
+
+import { Column, Text, TextInput } from './expo-ui';
+
+type ExpoTextInputProps = ComponentPropsWithoutRef<typeof TextInput>;
+const AccessibleTextInput = TextInput as unknown as ComponentType<ExpoTextInputProps & { accessibilityLabel?: string }>;
+
+type AppTextFieldEvent = NativeSyntheticEvent<TextInputFocusEventData>;
+
+export type AppTextFieldProps = ExpoTextInputProps & {
+  helperText?: string;
+  label: string;
+  onBlur?: (event: AppTextFieldEvent) => void;
+  onFocus?: (event: AppTextFieldEvent) => void;
+  testID?: string;
+};
+
+export function AppTextField({ helperText, label, onBlur, onFocus, style, testID, ...props }: AppTextFieldProps) {
+  const theme = useAppTheme();
+  const [isFocused, setIsFocused] = useState(false);
+
+  const labelStyle = {
+    color: theme.colors.onSurface,
+    fontSize: theme.typography.label.fontSize,
+    fontWeight: theme.typography.label.fontWeight,
+    lineHeight: theme.typography.label.lineHeight,
+  } satisfies TextStyle;
+
+  const helperStyle = {
+    color: theme.colors.muted,
+    fontSize: theme.typography.body.fontSize,
+    fontWeight: theme.typography.body.fontWeight,
+    lineHeight: theme.typography.body.lineHeight,
+  } satisfies TextStyle;
+
+  const handleBlur = ((event: AppTextFieldEvent) => {
+    setIsFocused(false);
+    onBlur?.(event);
+  }) as ExpoTextInputProps['onBlur'];
+
+  const handleFocus = ((event: AppTextFieldEvent) => {
+    setIsFocused(true);
+    onFocus?.(event);
+  }) as ExpoTextInputProps['onFocus'];
+
+  return (
+    <Column spacing={theme.space.xs} style={styles.container}>
+      <Text textStyle={labelStyle}>{label}</Text>
+      <AccessibleTextInput
+        accessibilityLabel={label}
+        onBlur={handleBlur}
+        onFocus={handleFocus}
+        placeholderTextColor={theme.colors.muted}
+        style={{
+          ...styles.input,
+          backgroundColor: theme.colors.surfaceRaised,
+          borderColor: isFocused ? theme.colors.focus : theme.colors.border,
+          height: theme.space.touchTarget,
+          paddingHorizontal: theme.space.md,
+          ...(StyleSheet.flatten(style) ?? {}),
+        }}
+        textStyle={{
+          color: theme.colors.onSurface,
+          fontSize: theme.typography.body.fontSize,
+          fontWeight: theme.typography.body.fontWeight,
+          lineHeight: theme.typography.body.lineHeight,
+        }}
+        testID={testID}
+        {...props}
+      />
+      {helperText ? <Text textStyle={helperStyle}>{helperText}</Text> : null}
+    </Column>
+  );
+}
+
+const styles = {
+  container: {
+    width: '100%',
+  },
+  input: {
+    borderRadius: 12,
+    borderWidth: 1,
+  },
+} as const;

--- a/src/components/ui/app-text.tsx
+++ b/src/components/ui/app-text.tsx
@@ -1,0 +1,11 @@
+import type { ComponentPropsWithoutRef } from 'react';
+
+import { Text } from './expo-ui';
+
+type ExpoTextProps = ComponentPropsWithoutRef<typeof Text>;
+
+export type AppTextProps = ExpoTextProps;
+
+export function AppText(props: AppTextProps) {
+  return <Text {...props} />;
+}

--- a/src/components/ui/expo-ui.mock.tsx
+++ b/src/components/ui/expo-ui.mock.tsx
@@ -1,0 +1,85 @@
+import type { ComponentPropsWithoutRef, PropsWithChildren, ReactNode } from 'react';
+import {
+  Pressable as RNPressable,
+  Text as RNText,
+  TextInput as RNTextInput,
+  View as RNView,
+  type StyleProp,
+  type TextStyle,
+  type ViewStyle,
+} from 'react-native';
+
+type BoxProps = {
+  children?: ReactNode;
+  spacing?: number;
+  style?: StyleProp<ViewStyle>;
+};
+
+type TextProps = {
+  children?: ReactNode;
+  style?: StyleProp<TextStyle>;
+  textStyle?: StyleProp<TextStyle>;
+};
+
+type ButtonProps = PropsWithChildren<{
+  label?: string;
+  variant?: string;
+} & ComponentPropsWithoutRef<typeof RNPressable>>;
+
+type HostProps = PropsWithChildren<{
+  colorScheme?: string;
+  style?: StyleProp<ViewStyle>;
+} & ComponentPropsWithoutRef<typeof RNView>>;
+
+type TextInputProps = ComponentPropsWithoutRef<typeof RNTextInput> & {
+  style?: StyleProp<ViewStyle>;
+  textStyle?: StyleProp<TextStyle>;
+};
+
+function withGap(style: StyleProp<ViewStyle> | undefined, spacing: number | undefined) {
+  return [style, spacing != null ? { gap: spacing } : null];
+}
+
+export function BottomSheet({ children, ...props }: PropsWithChildren<ComponentPropsWithoutRef<typeof RNView>>) {
+  return <RNView {...props}>{children}</RNView>;
+}
+
+export function Button({ children, label, variant: _variant, ...props }: ButtonProps) {
+  return <RNPressable {...props}>{children ?? <RNText>{label}</RNText>}</RNPressable>;
+}
+
+export function Column({ children, spacing, style, ...props }: BoxProps & ComponentPropsWithoutRef<typeof RNView>) {
+  return (
+    <RNView {...props} style={withGap(style, spacing)}>
+      {children}
+    </RNView>
+  );
+}
+
+export function Host({ children, colorScheme: _colorScheme, style, ...props }: HostProps) {
+  return (
+    <RNView {...props} style={style}>
+      {children}
+    </RNView>
+  );
+}
+
+export function Row({ children, spacing, style, ...props }: BoxProps & ComponentPropsWithoutRef<typeof RNView>) {
+  return (
+    <RNView {...props} style={withGap(style, spacing)}>
+      {children}
+    </RNView>
+  );
+}
+
+export function Text({ children, textStyle, style, ...props }: TextProps & ComponentPropsWithoutRef<typeof RNText>) {
+  return (
+    <RNText {...props} style={[style, textStyle]}>
+      {children}
+    </RNText>
+  );
+}
+
+export function TextInput({ style, textStyle, ...props }: TextInputProps) {
+  return <RNTextInput {...props} style={[style, textStyle]} />;
+}

--- a/src/components/ui/expo-ui.ts
+++ b/src/components/ui/expo-ui.ts
@@ -1,0 +1,1 @@
+export { BottomSheet, Button, Column, Host, Row, Text, TextInput } from '@expo/ui';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,9 @@
+export { AdSlot } from './ad-slot';
+export { AppColumn } from './app-column';
+export { AppButton } from './app-button';
+export { AppHost } from './app-host';
+export { AppRow } from './app-row';
+export { AppSelect } from './app-select';
+export { AppSheet } from './app-sheet';
+export { AppText } from './app-text';
+export { AppTextField } from './app-text-field';

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -5,21 +5,11 @@
 
 import { Platform } from 'react-native';
 
+import { semanticThemes } from '@/design-system/theme';
+
 export const Colors = {
-  light: {
-    text: '#000000',
-    background: '#ffffff',
-    backgroundElement: '#F0F0F3',
-    backgroundSelected: '#E0E1E6',
-    textSecondary: '#60646C',
-  },
-  dark: {
-    text: '#ffffff',
-    background: '#000000',
-    backgroundElement: '#212225',
-    backgroundSelected: '#2E3135',
-    textSecondary: '#B0B4BA',
-  },
+  light: semanticThemes.light.colors,
+  dark: semanticThemes.dark.colors,
 } as const;
 
 export type ThemeColor = keyof typeof Colors.light & keyof typeof Colors.dark;

--- a/src/design-system/index.ts
+++ b/src/design-system/index.ts
@@ -1,0 +1,2 @@
+export { AppThemeProvider, useAppTheme } from './theme-context';
+export { resolveSemanticTheme, resolveThemeMode, semanticThemes } from './theme';

--- a/src/design-system/theme-context.tsx
+++ b/src/design-system/theme-context.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+
+import type { ThemeMode, ThemePreference } from '@/stores/theme-preferences';
+
+import { resolveSemanticTheme, type SemanticTheme } from './theme';
+
+type AppThemeProviderProps = {
+  children: ReactNode;
+  systemScheme: ThemeMode | 'unspecified' | null | undefined;
+  themePreference: ThemePreference;
+};
+
+const fallbackTheme = resolveSemanticTheme('system', 'unspecified');
+
+const AppThemeContext = createContext<SemanticTheme>(fallbackTheme);
+
+export function AppThemeProvider({ children, systemScheme, themePreference }: AppThemeProviderProps) {
+  const theme = useMemo(
+    () => resolveSemanticTheme(themePreference, systemScheme),
+    [systemScheme, themePreference]
+  );
+
+  return <AppThemeContext.Provider value={theme}>{children}</AppThemeContext.Provider>;
+}
+
+export function useAppTheme() {
+  return useContext(AppThemeContext);
+}

--- a/src/design-system/theme.test.ts
+++ b/src/design-system/theme.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { resolveSemanticTheme, resolveThemeMode, semanticThemes } from './theme';
+
+describe('semantic theme resolver', () => {
+  it('resolves system, light, and dark modes deterministically', () => {
+    expect(resolveThemeMode('light', 'dark')).toBe('light');
+    expect(resolveThemeMode('dark', 'light')).toBe('dark');
+    expect(resolveThemeMode('system', 'dark')).toBe('dark');
+    expect(resolveThemeMode('system', 'unspecified')).toBe('light');
+  });
+
+  it('returns semantic token sets for both modes', () => {
+    expect(resolveSemanticTheme('light', 'dark')).toEqual(semanticThemes.light);
+    expect(resolveSemanticTheme('system', 'dark')).toEqual(semanticThemes.dark);
+  });
+});

--- a/src/design-system/theme.ts
+++ b/src/design-system/theme.ts
@@ -1,0 +1,178 @@
+import type { ThemeMode, ThemePreference } from '@/stores/theme-preferences';
+
+import { DEFAULT_LANGUAGE, type SupportedLanguage } from '@/lib/localization/resources';
+
+export type SemanticColorTokens = {
+  surface: string;
+  surfaceRaised: string;
+  onSurface: string;
+  muted: string;
+  border: string;
+  focus: string;
+  budgetSafe: string;
+  budgetRisk: string;
+  budgetNeutral: string;
+  background: string;
+  backgroundElement: string;
+  backgroundSelected: string;
+  text: string;
+  textSecondary: string;
+};
+
+export type SemanticTypographyTokens = {
+  body: { fontSize: number; lineHeight: number; fontWeight: '400' | '500' | '600' | '700' };
+  label: { fontSize: number; lineHeight: number; fontWeight: '500' | '600' | '700' };
+  title: { fontSize: number; lineHeight: number; fontWeight: '600' | '700' };
+  display: { fontSize: number; lineHeight: number; fontWeight: '700' };
+  numeric: { fontSize: number; lineHeight: number; fontWeight: '500' | '600' | '700'; fontVariant: ['tabular-nums'] };
+};
+
+export type SemanticSpaceTokens = {
+  xxs: number;
+  xs: number;
+  sm: number;
+  md: number;
+  lg: number;
+  xl: number;
+  content: number;
+  touchTarget: number;
+  contentMax: number;
+};
+
+export type SemanticRadiusTokens = {
+  sm: number;
+  md: number;
+  lg: number;
+  xl: number;
+  pill: number;
+};
+
+export type SemanticMotionTokens = {
+  none: number;
+  fast: number;
+  standard: number;
+  slow: number;
+};
+
+export type SemanticTheme = {
+  mode: ThemeMode;
+  colors: SemanticColorTokens;
+  typography: SemanticTypographyTokens;
+  space: SemanticSpaceTokens;
+  radius: SemanticRadiusTokens;
+  motion: SemanticMotionTokens;
+};
+
+export type SemanticThemePreference = ThemePreference;
+
+export type LocaleLike = {
+  currencyCode?: string | null;
+  languageCode?: string | null;
+  languageTag?: string | null;
+  regionCode?: string | null;
+};
+
+const SHARED_TYPOGRAPHY: Omit<SemanticTheme, 'mode' | 'colors'>['typography'] = {
+  body: { fontSize: 16, lineHeight: 24, fontWeight: '400' },
+  label: { fontSize: 14, lineHeight: 20, fontWeight: '600' },
+  title: { fontSize: 24, lineHeight: 30, fontWeight: '700' },
+  display: { fontSize: 32, lineHeight: 38, fontWeight: '700' },
+  numeric: { fontSize: 16, lineHeight: 24, fontWeight: '600', fontVariant: ['tabular-nums'] },
+};
+
+const SHARED_SPACE: Omit<SemanticTheme, 'mode' | 'colors' | 'typography'>['space'] = {
+  xxs: 4,
+  xs: 8,
+  sm: 12,
+  md: 16,
+  lg: 24,
+  xl: 32,
+  content: 24,
+  touchTarget: 44,
+  contentMax: 800,
+};
+
+const SHARED_RADIUS: Omit<SemanticTheme, 'mode' | 'colors' | 'typography' | 'space'>['radius'] = {
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 24,
+  pill: 999,
+};
+
+const SHARED_MOTION: Omit<SemanticTheme, 'mode' | 'colors' | 'typography' | 'space' | 'radius'>['motion'] = {
+  none: 0,
+  fast: 120,
+  standard: 200,
+  slow: 280,
+};
+
+const LIGHT_COLORS: SemanticColorTokens = {
+  surface: '#FFFFFF',
+  surfaceRaised: '#F5F7FA',
+  onSurface: '#172B4D',
+  muted: '#44546F',
+  border: '#D7DFEA',
+  focus: '#208AEF',
+  budgetSafe: '#2E7D32',
+  budgetRisk: '#C62828',
+  budgetNeutral: '#5C6B8A',
+  background: '#FFFFFF',
+  backgroundElement: '#F0F4F8',
+  backgroundSelected: '#E6EEF8',
+  text: '#172B4D',
+  textSecondary: '#44546F',
+};
+
+const DARK_COLORS: SemanticColorTokens = {
+  surface: '#111827',
+  surfaceRaised: '#1F2937',
+  onSurface: '#F3F4F6',
+  muted: '#C7D2E0',
+  border: '#334155',
+  focus: '#66B2FF',
+  budgetSafe: '#4CAF50',
+  budgetRisk: '#EF5350',
+  budgetNeutral: '#94A3B8',
+  background: '#0B1220',
+  backgroundElement: '#162033',
+  backgroundSelected: '#1E3A5F',
+  text: '#F3F4F6',
+  textSecondary: '#C7D2E0',
+};
+
+const createSemanticTheme = (mode: ThemeMode, colors: SemanticColorTokens): SemanticTheme => ({
+  mode,
+  colors,
+  typography: SHARED_TYPOGRAPHY,
+  space: SHARED_SPACE,
+  radius: SHARED_RADIUS,
+  motion: SHARED_MOTION,
+});
+
+export const semanticThemes = {
+  dark: createSemanticTheme('dark', DARK_COLORS),
+  light: createSemanticTheme('light', LIGHT_COLORS),
+} as const;
+
+export function resolveThemeMode(
+  themePreference: SemanticThemePreference,
+  systemScheme: ThemeMode | 'unspecified' | null | undefined
+): ThemeMode {
+  if (themePreference !== 'system') {
+    return themePreference;
+  }
+
+  return systemScheme === 'dark' ? 'dark' : 'light';
+}
+
+export function resolveSemanticTheme(
+  themePreference: SemanticThemePreference,
+  systemScheme: ThemeMode | 'unspecified' | null | undefined
+): SemanticTheme {
+  const mode = resolveThemeMode(themePreference, systemScheme);
+
+  return semanticThemes[mode];
+}
+
+export const DEFAULT_SEMANTIC_LANGUAGE: SupportedLanguage = DEFAULT_LANGUAGE;

--- a/src/lib/localization/i18n.test.ts
+++ b/src/lib/localization/i18n.test.ts
@@ -8,12 +8,18 @@ describe('i18n bundle', () => {
 
     expect(i18n.t('app.readyTitle')).toBe('Base do Expo pronta');
     expect(i18n.t('preferences.currencyUsd')).toBe('dólar americano');
+    expect(i18n.t('app.designPreviewTitle')).toBe('Prévia do design system');
+    expect(i18n.t('form.searchPlaceholder')).toBe('Mantimentos do orçamento');
     expect(i18n.t('app.loading')).toBe('Carregando a base do app…');
 
     await i18n.changeLanguage('en');
 
     expect(i18n.t('app.readyTitle')).toBe('Expo foundation ready');
     expect(i18n.t('preferences.currencyUsd')).toBe('US dollar');
+    expect(i18n.t('app.designPreviewBody')).toBe(
+      'Semantic tokens, adapters, and theme resolution are wired up.'
+    );
+    expect(i18n.t('form.searchPlaceholder')).toBe('Budget groceries');
     expect(i18n.t('app.error')).toBe('Unable to start the app shell.');
   });
 });

--- a/src/lib/localization/resources.ts
+++ b/src/lib/localization/resources.ts
@@ -12,6 +12,15 @@ export const localizationResources = {
         readyTitle: 'Expo foundation ready',
         loading: 'Loading app shell…',
         error: 'Unable to start the app shell.',
+        designPreviewBody: 'Semantic tokens, adapters, and theme resolution are wired up.',
+        designPreviewTitle: 'Design system preview',
+      },
+      form: {
+        currencyLabel: 'Currency',
+        searchHelper: 'Styled by semantic tokens, not screen colors.',
+        searchLabel: 'Search',
+        searchPlaceholder: 'Budget groceries',
+        openSheet: 'Open sheet',
       },
       preferences: {
         currencyBrl: 'Brazilian real',
@@ -28,6 +37,15 @@ export const localizationResources = {
         readyTitle: 'Base do Expo pronta',
         loading: 'Carregando a base do app…',
         error: 'Não foi possível iniciar a base do app.',
+        designPreviewBody: 'Tokens semânticos, adapters e resolução de tema já estão conectados.',
+        designPreviewTitle: 'Prévia do design system',
+      },
+      form: {
+        currencyLabel: 'Moeda',
+        searchHelper: 'Estilizado por tokens semânticos, não por cores da tela.',
+        searchLabel: 'Buscar',
+        searchPlaceholder: 'Mantimentos do orçamento',
+        openSheet: 'Abrir painel',
       },
       preferences: {
         currencyBrl: 'real brasileiro',

--- a/src/stores/theme-preferences.test.ts
+++ b/src/stores/theme-preferences.test.ts
@@ -18,6 +18,7 @@ describe('theme preferences store', () => {
       default: { getItem, setItem, removeItem },
     }));
 
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { resolveThemeMode, useThemePreferencesStore } = require('./theme-preferences') as typeof import('./theme-preferences');
 
     await useThemePreferencesStore.persist.rehydrate();
@@ -36,6 +37,7 @@ describe('theme preferences store', () => {
       default: { getItem, setItem, removeItem },
     }));
 
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { THEME_PREFERENCES_STORAGE_KEY, useThemePreferencesStore } = require(
       './theme-preferences'
     ) as typeof import('./theme-preferences');

--- a/src/stores/theme-preferences.ts
+++ b/src/stores/theme-preferences.ts
@@ -2,6 +2,10 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
+import { resolveThemeMode } from '@/design-system/theme';
+
+export { resolveThemeMode };
+
 export type ThemePreference = 'system' | 'light' | 'dark';
 
 export type ThemeMode = 'light' | 'dark';
@@ -12,17 +16,6 @@ type ThemePreferencesState = {
 };
 
 export const THEME_PREFERENCES_STORAGE_KEY = 'theme-preferences-v1';
-
-export function resolveThemeMode(
-  themePreference: ThemePreference,
-  systemScheme: ThemeMode | 'unspecified' | null | undefined
-): ThemeMode {
-  if (themePreference !== 'system') {
-    return themePreference;
-  }
-
-  return systemScheme === 'dark' ? 'dark' : 'light';
-}
 
 export const useThemePreferencesStore = create<ThemePreferencesState>()(
   persist(


### PR DESCRIPTION
## Summary
- Adds semantic theme tokens with System, Light, and Dark resolution.
- Adds `AppHost` and project-owned `@expo/ui` adapters, including platform-isolated ad slots.
- Adds accessibility and adapter-boundary coverage.

## Validation
- `npm test -- --runInBand`
- `npm run lint`
- `npm run typecheck`