### PR TITLE
feat(v2): add domain persistence foundation

### DIFF
--- a/src/domain/shopping-list-repository.ts
+++ b/src/domain/shopping-list-repository.ts
@@ -1,0 +1,12 @@
+import type { ShoppingList } from './shopping-list';
+
+export type ShoppingListQuery = {
+  includeDeleted?: boolean;
+  status?: readonly ShoppingList['status'][];
+};
+
+export type ShoppingListRepository = {
+  get: (id: string, query?: ShoppingListQuery) => Promise<ShoppingList | null>;
+  list: (query?: ShoppingListQuery) => Promise<readonly ShoppingList[]>;
+  save: (shoppingList: ShoppingList) => Promise<void>;
+};

--- a/src/domain/shopping-list-use-cases.test.ts
+++ b/src/domain/shopping-list-use-cases.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { createShoppingListUseCases } from './shopping-list-use-cases';
+import type { ShoppingList } from './shopping-list';
+import type { ShoppingListRepository } from './shopping-list-repository';
+
+function createShoppingList(): ShoppingList {
+  return {
+    budgetMinor: 4000,
+    createdAt: '2026-07-31T00:00:00.000Z',
+    currencyCode: 'BRL',
+    deletedAt: null,
+    finalizedAt: null,
+    id: 'list-1',
+    items: [
+      {
+        actualUnitMinor: null,
+        createdAt: '2026-07-31T00:00:00.000Z',
+        deletedAt: null,
+        id: 'item-1',
+        listId: 'list-1',
+        name: 'Milk',
+        plannedUnitMinor: 600,
+        purchasedAt: null,
+        quantityMilli: 2000,
+        sortOrder: 1,
+        unitCode: 'piece',
+        updatedAt: '2026-07-31T00:00:00.000Z',
+      },
+    ],
+    name: 'Weekly groceries',
+    status: 'draft',
+    updatedAt: '2026-07-31T00:00:00.000Z',
+  };
+}
+
+describe('createShoppingListUseCases', () => {
+  it('sets actual price explicitly when purchasing and preserves it on unpurchase', async () => {
+    const list = createShoppingList();
+    const repository: ShoppingListRepository = {
+      get: jest.fn(async () => list),
+      list: jest.fn(async () => [list]),
+      save: jest.fn(async () => undefined),
+    };
+    const useCases = createShoppingListUseCases({
+      now: () => '2026-07-31T10:00:00.000Z',
+      repository,
+    });
+
+    const purchased = await useCases.setItemPurchased('list-1', 'item-1', 650);
+    const unpurchased = await useCases.setItemUnpurchased('list-1', 'item-1');
+
+    expect(purchased.items[0]).toMatchObject({
+      actualUnitMinor: 650,
+      purchasedAt: '2026-07-31T10:00:00.000Z',
+    });
+    expect(unpurchased.items[0]).toMatchObject({
+      actualUnitMinor: null,
+      purchasedAt: null,
+    });
+    expect(repository.save).toHaveBeenCalledTimes(2);
+  });
+
+  it('refuses to mutate deleted lists or deleted items', async () => {
+    const deletedList = createShoppingList();
+    const deletedItemList = createShoppingList();
+    deletedList.deletedAt = '2026-07-31T00:00:00.000Z';
+    deletedItemList.items = [
+      {
+        ...deletedItemList.items[0],
+        deletedAt: '2026-07-31T00:00:00.000Z',
+      },
+    ];
+
+    const repository: ShoppingListRepository = {
+      get: jest.fn(async (id) => (id === 'deleted-item-list' ? deletedItemList : deletedList)),
+      list: jest.fn(async () => [deletedList, deletedItemList]),
+      save: jest.fn(async () => undefined),
+    };
+    const useCases = createShoppingListUseCases({
+      now: () => '2026-07-31T10:00:00.000Z',
+      repository,
+    });
+
+    await expect(useCases.setItemPurchased('deleted-list', 'item-1', 650)).rejects.toThrow(
+      'Cannot mutate a deleted shopping list.'
+    );
+    await expect(useCases.setItemUnpurchased('deleted-item-list', 'item-1')).rejects.toThrow(
+      'Cannot mutate a deleted shopping list item.'
+    );
+    expect(repository.save).not.toHaveBeenCalled();
+  });
+});

--- a/src/domain/shopping-list-use-cases.ts
+++ b/src/domain/shopping-list-use-cases.ts
@@ -1,0 +1,57 @@
+import type { ShoppingList } from './shopping-list';
+import {
+  markShoppingListItemPurchased,
+  markShoppingListItemUnpurchased,
+  validateShoppingList,
+} from './shopping-list';
+import type { ShoppingListRepository } from './shopping-list-repository';
+
+export type ShoppingListUseCaseDependencies = {
+  now?: () => string;
+  repository: ShoppingListRepository;
+};
+
+export type ShoppingListUseCases = {
+  loadList: (id: string, includeDeleted?: boolean) => Promise<ShoppingList | null>;
+  saveList: (list: ShoppingList) => Promise<void>;
+  setItemPurchased: (listId: string, itemId: string, actualUnitMinor: number) => Promise<ShoppingList>;
+  setItemUnpurchased: (listId: string, itemId: string) => Promise<ShoppingList>;
+};
+
+function requireLoadedList(list: ShoppingList | null, listId: string): ShoppingList {
+  if (list === null) {
+    throw new Error(`Shopping list not found: ${listId}`);
+  }
+
+  return list;
+}
+
+export function createShoppingListUseCases({ now = () => new Date().toISOString(), repository }: ShoppingListUseCaseDependencies): ShoppingListUseCases {
+  return {
+    loadList: async (id, includeDeleted = false) => repository.get(id, { includeDeleted }),
+    saveList: async (list) => {
+      const validation = validateShoppingList(list);
+
+      if (!validation.success) {
+        throw new Error(validation.errors.map((issue) => `${issue.field}: ${issue.message}`).join('; '));
+      }
+
+      await repository.save(list);
+    },
+    setItemPurchased: async (listId, itemId, actualUnitMinor) => {
+      const list = requireLoadedList(await repository.get(listId), listId);
+      const purchasedAt = now();
+      const updated = markShoppingListItemPurchased(list, itemId, actualUnitMinor, purchasedAt);
+
+      await repository.save(updated);
+      return updated;
+    },
+    setItemUnpurchased: async (listId, itemId) => {
+      const list = requireLoadedList(await repository.get(listId), listId);
+      const updated = markShoppingListItemUnpurchased(list, itemId, now());
+
+      await repository.save(updated);
+      return updated;
+    },
+  };
+}

--- a/src/domain/shopping-list.test.ts
+++ b/src/domain/shopping-list.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  calculateShoppingListItemActualMinor,
+  calculateShoppingListItemPlannedMinor,
+  calculateShoppingListTotals,
+  markShoppingListItemPurchased,
+  markShoppingListItemUnpurchased,
+  validateShoppingList,
+  validateShoppingListItem,
+  type ShoppingList,
+  type ShoppingListItem,
+} from './shopping-list';
+
+function createItem(overrides: Partial<ShoppingListItem> = {}): ShoppingListItem {
+  return {
+    actualUnitMinor: null,
+    createdAt: '2026-07-31T00:00:00.000Z',
+    deletedAt: null,
+    id: 'item-1',
+    listId: 'list-1',
+    name: 'Milk',
+    plannedUnitMinor: 600,
+    purchasedAt: null,
+    quantityMilli: 2000,
+    sortOrder: 1,
+    unitCode: 'piece',
+    updatedAt: '2026-07-31T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function createShoppingList(overrides: Partial<ShoppingList> = {}): ShoppingList {
+  const milk = createItem({ actualUnitMinor: 650, purchasedAt: '2026-07-31T00:00:00.000Z' });
+  const rice = createItem({
+    actualUnitMinor: null,
+    id: 'item-2',
+    name: 'Rice',
+    plannedUnitMinor: 2500,
+    quantityMilli: 1000,
+    sortOrder: 2,
+  });
+
+  return {
+    budgetMinor: 4000,
+    createdAt: '2026-07-31T00:00:00.000Z',
+    currencyCode: 'BRL',
+    deletedAt: null,
+    finalizedAt: null,
+    id: 'list-1',
+    items: [milk, rice],
+    name: 'Weekly groceries',
+    status: 'draft',
+    updatedAt: '2026-07-31T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('shopping list domain', () => {
+  it('calculates planned and actual totals using integer math only', () => {
+    const list = createShoppingList();
+
+    expect(calculateShoppingListItemPlannedMinor(list.items[0])).toBe(1200);
+    expect(calculateShoppingListItemActualMinor(list.items[0])).toBe(1300);
+    expect(calculateShoppingListTotals(list)).toEqual({
+      actualMinor: 1300,
+      plannedMinor: 3700,
+      remainingMinor: 2700,
+      varianceMinor: -2400,
+    });
+  });
+
+  it('rounds kilogram totals without floats', () => {
+    const item = createItem({
+      id: 'item-kg',
+      listId: 'list-kg',
+      name: 'Potatoes',
+      plannedUnitMinor: 200,
+      quantityMilli: 1500,
+      unitCode: 'kg',
+    });
+
+    expect(calculateShoppingListItemPlannedMinor(item)).toBe(300);
+  });
+
+  it('rejects invalid whole-unit precision and purchased items without actual price', () => {
+    const invalidWholeUnit = createItem({ quantityMilli: 1500, unitCode: 'piece' });
+    const purchasedWithoutActualPrice = createItem({ actualUnitMinor: null, purchasedAt: '2026-07-31T00:00:00.000Z' });
+
+    expect(validateShoppingListItem(invalidWholeUnit).success).toBe(false);
+    expect(validateShoppingListItem(purchasedWithoutActualPrice).success).toBe(false);
+  });
+
+  it('rejects unsafe integer money and quantity values at validation and calculation boundaries', () => {
+    const unsafeInteger = Number.MAX_SAFE_INTEGER + 1;
+
+    expect(validateShoppingList(createShoppingList({ budgetMinor: unsafeInteger })).success).toBe(false);
+    expect(validateShoppingListItem(createItem({ quantityMilli: unsafeInteger })).success).toBe(false);
+    expect(() => calculateShoppingListItemPlannedMinor(createItem({ quantityMilli: unsafeInteger }))).toThrow(
+      'safe integers'
+    );
+  });
+
+  it('rejects invalid closed enums and negative money values', () => {
+    const validation = validateShoppingList(
+      createShoppingList({
+        budgetMinor: -1,
+        currencyCode: 'EUR' as never,
+        status: 'paused' as never,
+      })
+    );
+
+    expect(validation.success).toBe(false);
+  });
+
+  it('retains actual price when an item is marked unpurchased', () => {
+    const list = createShoppingList();
+    const purchased = markShoppingListItemPurchased(list, 'item-2', 2500, '2026-07-31T00:00:00.000Z');
+    const unpurchased = markShoppingListItemUnpurchased(purchased, 'item-2', '2026-07-31T00:00:01.000Z');
+
+    expect(unpurchased.items[1]).toMatchObject({
+      actualUnitMinor: 2500,
+      purchasedAt: null,
+    });
+    expect(calculateShoppingListTotals(unpurchased)).toEqual({
+      actualMinor: 1300,
+      plannedMinor: 3700,
+      remainingMinor: 2700,
+      varianceMinor: -2400,
+    });
+  });
+
+  it('rejects mutations on soft-deleted lists and items', () => {
+    const deletedList = createShoppingList({
+      deletedAt: '2026-07-31T00:00:00.000Z',
+    });
+    const deletedItemList = createShoppingList({
+      items: [
+        createItem({
+          deletedAt: '2026-07-31T00:00:00.000Z',
+        }),
+      ],
+    });
+
+    expect(() => markShoppingListItemPurchased(deletedList, 'item-1', 650, '2026-07-31T10:00:00.000Z')).toThrow(
+      'Cannot mutate a deleted shopping list.'
+    );
+    expect(() => markShoppingListItemUnpurchased(deletedItemList, 'item-1', '2026-07-31T10:00:00.000Z')).toThrow(
+      'Cannot mutate a deleted shopping list item.'
+    );
+  });
+
+  it('ignores deleted items when calculating totals', () => {
+    const list = createShoppingList({
+      items: [
+        createItem({ actualUnitMinor: 650, purchasedAt: '2026-07-31T00:00:00.000Z' }),
+        createItem({
+          deletedAt: '2026-07-31T00:00:00.000Z',
+          id: 'item-2',
+          actualUnitMinor: 900,
+          purchasedAt: '2026-07-31T00:00:00.000Z',
+        }),
+      ],
+    });
+
+    expect(calculateShoppingListTotals(list)).toEqual({
+      actualMinor: 1300,
+      plannedMinor: 1200,
+      remainingMinor: 2700,
+      varianceMinor: 100,
+    });
+  });
+
+  it('validates shopping list names and linked items', () => {
+    const list = createShoppingList({
+      items: [
+        createItem({ listId: 'other-list', name: '   ' }),
+      ],
+      name: '   ',
+    });
+
+    const validation = validateShoppingList(list);
+
+    expect(validation.success).toBe(false);
+    expect(validation).toMatchObject({
+      success: false,
+    });
+  });
+});

--- a/src/domain/shopping-list.ts
+++ b/src/domain/shopping-list.ts
@@ -1,0 +1,386 @@
+import type { SupportedCurrency } from '@/lib/localization/resolution';
+
+export type ShoppingListUnitCode = 'piece' | 'pack' | 'kg' | 'g' | 'l' | 'ml';
+
+export type ShoppingListStatus = 'draft' | 'active' | 'finalized';
+
+export type ShoppingListTotals = {
+  actualMinor: number;
+  plannedMinor: number;
+  remainingMinor: number;
+  varianceMinor: number;
+};
+
+export type ShoppingListItem = {
+  actualUnitMinor: number | null;
+  createdAt: string;
+  deletedAt: string | null;
+  id: string;
+  listId: string;
+  name: string;
+  plannedUnitMinor: number;
+  purchasedAt: string | null;
+  quantityMilli: number;
+  sortOrder: number;
+  unitCode: ShoppingListUnitCode;
+  updatedAt: string;
+};
+
+export type ShoppingList = {
+  budgetMinor: number;
+  createdAt: string;
+  currencyCode: SupportedCurrency;
+  deletedAt: string | null;
+  finalizedAt: string | null;
+  id: string;
+  items: readonly ShoppingListItem[];
+  name: string;
+  status: ShoppingListStatus;
+  updatedAt: string;
+};
+
+export type ShoppingListValidationIssue = {
+  field: string;
+  message: string;
+};
+
+export type ValidationResult<T> =
+  | {
+      success: true;
+      value: T;
+    }
+  | {
+      errors: readonly ShoppingListValidationIssue[];
+      success: false;
+    };
+
+const SHARED_UNIT_CODES = new Set<ShoppingListUnitCode>(['piece', 'pack', 'kg', 'g', 'l', 'ml']);
+
+const WHOLE_UNITS = new Set<ShoppingListUnitCode>(['piece', 'pack', 'g', 'ml']);
+
+const SHARED_STATUSES = new Set<ShoppingListStatus>(['draft', 'active', 'finalized']);
+
+const SHARED_CURRENCIES = new Set<SupportedCurrency>(['BRL', 'USD']);
+
+function isSafeNonNegativeInteger(value: number): boolean {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+function isSafePositiveInteger(value: number): boolean {
+  return Number.isSafeInteger(value) && value > 0;
+}
+
+function isValidTimestamp(value: string): boolean {
+  return value.trim().length > 0 && !Number.isNaN(Date.parse(value));
+}
+
+export function normalizeShoppingListName(name: string): string {
+  return name.trim();
+}
+
+export function isSupportedShoppingListUnitCode(unitCode: string): unitCode is ShoppingListUnitCode {
+  return SHARED_UNIT_CODES.has(unitCode as ShoppingListUnitCode);
+}
+
+export function isSupportedShoppingListStatus(status: string): status is ShoppingListStatus {
+  return SHARED_STATUSES.has(status as ShoppingListStatus);
+}
+
+export function isSupportedShoppingListCurrency(currencyCode: string): currencyCode is SupportedCurrency {
+  return SHARED_CURRENCIES.has(currencyCode as SupportedCurrency);
+}
+
+export function validateShoppingListQuantity(
+  unitCode: ShoppingListUnitCode,
+  quantityMilli: number
+): ValidationResult<number> {
+  const issues: ShoppingListValidationIssue[] = [];
+
+  if (!Number.isSafeInteger(quantityMilli)) {
+    issues.push({ field: 'quantityMilli', message: 'Quantity must be an integer.' });
+  } else if (quantityMilli <= 0) {
+    issues.push({ field: 'quantityMilli', message: 'Quantity must be greater than zero.' });
+  }
+
+  if (Number.isSafeInteger(quantityMilli) && quantityMilli > 0 && WHOLE_UNITS.has(unitCode)) {
+    if (quantityMilli % 1000 !== 0) {
+      issues.push({
+        field: 'quantityMilli',
+        message: 'Whole-unit quantities must be divisible by 1000.',
+      });
+    }
+  }
+
+  return issues.length > 0 ? { success: false, errors: issues } : { success: true, value: quantityMilli };
+}
+
+export function validateShoppingListItem(item: ShoppingListItem): ValidationResult<ShoppingListItem> {
+  const issues: ShoppingListValidationIssue[] = [];
+
+  if (normalizeShoppingListName(item.name).length === 0) {
+    issues.push({ field: 'name', message: 'Item name is required.' });
+  }
+
+  if (!isSupportedShoppingListUnitCode(item.unitCode)) {
+    issues.push({ field: 'unitCode', message: 'Unit code is invalid.' });
+  }
+
+  if (!isSafePositiveInteger(item.sortOrder)) {
+    issues.push({ field: 'sortOrder', message: 'Sort order must be a positive integer.' });
+  }
+
+  if (!isSafeNonNegativeInteger(item.plannedUnitMinor)) {
+    issues.push({ field: 'plannedUnitMinor', message: 'Planned unit price must be a non-negative integer.' });
+  }
+
+  if (item.actualUnitMinor !== null && !isSafeNonNegativeInteger(item.actualUnitMinor)) {
+    issues.push({ field: 'actualUnitMinor', message: 'Actual unit price must be a non-negative integer or null.' });
+  }
+
+  if (!isValidTimestamp(item.createdAt)) {
+    issues.push({ field: 'createdAt', message: 'Created timestamp is required.' });
+  }
+
+  if (!isValidTimestamp(item.updatedAt)) {
+    issues.push({ field: 'updatedAt', message: 'Updated timestamp is required.' });
+  }
+
+  if (item.deletedAt !== null && !isValidTimestamp(item.deletedAt)) {
+    issues.push({ field: 'deletedAt', message: 'Deleted timestamp must be a valid timestamp or null.' });
+  }
+
+  if (item.purchasedAt !== null && !isValidTimestamp(item.purchasedAt)) {
+    issues.push({ field: 'purchasedAt', message: 'Purchased timestamp must be a valid timestamp or null.' });
+  }
+
+  if (isSupportedShoppingListUnitCode(item.unitCode)) {
+    const quantityValidation = validateShoppingListQuantity(item.unitCode, item.quantityMilli);
+
+    if (!quantityValidation.success) {
+      issues.push(...quantityValidation.errors);
+    }
+  }
+
+  if (item.purchasedAt !== null && item.actualUnitMinor === null) {
+    issues.push({
+      field: 'actualUnitMinor',
+      message: 'Purchased items require an explicit actual unit price.',
+    });
+  }
+
+  return issues.length > 0 ? { success: false, errors: issues } : { success: true, value: item };
+}
+
+export function validateShoppingList(list: ShoppingList): ValidationResult<ShoppingList> {
+  const issues: ShoppingListValidationIssue[] = [];
+
+  if (normalizeShoppingListName(list.name).length === 0) {
+    issues.push({ field: 'name', message: 'List name is required.' });
+  }
+
+  if (!isSafeNonNegativeInteger(list.budgetMinor)) {
+    issues.push({ field: 'budgetMinor', message: 'Budget must be a non-negative integer.' });
+  }
+
+  if (!isSupportedShoppingListCurrency(list.currencyCode)) {
+    issues.push({ field: 'currencyCode', message: 'Currency code is invalid.' });
+  }
+
+  if (!isSupportedShoppingListStatus(list.status)) {
+    issues.push({ field: 'status', message: 'Status is invalid.' });
+  }
+
+  if (!isValidTimestamp(list.createdAt)) {
+    issues.push({ field: 'createdAt', message: 'Created timestamp is required.' });
+  }
+
+  if (!isValidTimestamp(list.updatedAt)) {
+    issues.push({ field: 'updatedAt', message: 'Updated timestamp is required.' });
+  }
+
+  if (list.deletedAt !== null && !isValidTimestamp(list.deletedAt)) {
+    issues.push({ field: 'deletedAt', message: 'Deleted timestamp must be a valid timestamp or null.' });
+  }
+
+  if (list.finalizedAt !== null && !isValidTimestamp(list.finalizedAt)) {
+    issues.push({ field: 'finalizedAt', message: 'Finalized timestamp must be a valid timestamp or null.' });
+  }
+
+  for (const item of list.items) {
+    const validation = validateShoppingListItem(item);
+
+    if (!validation.success) {
+      issues.push(...validation.errors.map((issue) => ({ field: `items.${item.id}.${issue.field}`, message: issue.message })));
+    }
+
+    if (item.listId !== list.id) {
+      issues.push({ field: `items.${item.id}.listId`, message: 'Item list id must match the parent list.' });
+    }
+  }
+
+  return issues.length > 0 ? { success: false, errors: issues } : { success: true, value: list };
+}
+
+export function roundMinorUnits(quantityMilli: number, unitMinor: number): number {
+  if (!Number.isSafeInteger(quantityMilli) || !Number.isSafeInteger(unitMinor)) {
+    throw new Error('Quantity and unit price must be safe integers.');
+  }
+
+  if (quantityMilli < 0 || unitMinor < 0) {
+    throw new Error('Quantity and unit price must be non-negative.');
+  }
+
+  const scaled = BigInt(quantityMilli) * BigInt(unitMinor);
+  const rounded = (scaled + 500n) / 1000n;
+
+  if (rounded > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error('Calculated money exceeds the safe integer range.');
+  }
+
+  return Number(rounded);
+}
+
+export function calculateShoppingListItemPlannedMinor(item: ShoppingListItem): number {
+  return roundMinorUnits(item.quantityMilli, item.plannedUnitMinor);
+}
+
+export function calculateShoppingListItemActualMinor(item: ShoppingListItem): number {
+  if (item.purchasedAt === null || item.actualUnitMinor === null) {
+    return 0;
+  }
+
+  return roundMinorUnits(item.quantityMilli, item.actualUnitMinor);
+}
+
+export function calculateShoppingListTotals(list: ShoppingList): ShoppingListTotals {
+  const visibleItems = list.items.filter((item) => item.deletedAt === null);
+
+  const plannedMinor = visibleItems.reduce((total, item) => {
+    const nextTotal = total + calculateShoppingListItemPlannedMinor(item);
+
+    if (!Number.isSafeInteger(nextTotal)) {
+      throw new Error('Calculated money exceeds the safe integer range.');
+    }
+
+    return nextTotal;
+  }, 0);
+  const actualMinor = visibleItems.reduce((total, item) => {
+    const nextTotal = total + calculateShoppingListItemActualMinor(item);
+
+    if (!Number.isSafeInteger(nextTotal)) {
+      throw new Error('Calculated money exceeds the safe integer range.');
+    }
+
+    return nextTotal;
+  }, 0);
+
+  if (!Number.isSafeInteger(list.budgetMinor)) {
+    throw new Error('Budget must be a safe integer.');
+  }
+
+  const remainingMinor = list.budgetMinor - actualMinor;
+  const varianceMinor = actualMinor - plannedMinor;
+
+  if (!Number.isSafeInteger(remainingMinor) || !Number.isSafeInteger(varianceMinor)) {
+    throw new Error('Calculated money exceeds the safe integer range.');
+  }
+
+  return {
+    actualMinor,
+    plannedMinor,
+    remainingMinor,
+    varianceMinor,
+  };
+}
+
+function assertShoppingListIsMutable(list: ShoppingList): void {
+  if (list.deletedAt !== null) {
+    throw new Error('Cannot mutate a deleted shopping list.');
+  }
+}
+
+function assertShoppingListItemIsMutable(list: ShoppingList, item: ShoppingListItem): void {
+  assertShoppingListIsMutable(list);
+
+  if (item.deletedAt !== null) {
+    throw new Error('Cannot mutate a deleted shopping list item.');
+  }
+}
+
+export function markShoppingListItemPurchased(
+  list: ShoppingList,
+  itemId: string,
+  actualUnitMinor: number,
+  purchasedAt: string
+): ShoppingList {
+  assertShoppingListIsMutable(list);
+
+  if (!isSafeNonNegativeInteger(actualUnitMinor)) {
+    throw new Error('Actual unit price must be a non-negative integer.');
+  }
+
+  if (!isValidTimestamp(purchasedAt)) {
+    throw new Error('Purchased timestamp is required.');
+  }
+
+  let itemFound = false;
+  const items = list.items.map((item) => {
+    if (item.id !== itemId) {
+      return item;
+    }
+
+    assertShoppingListItemIsMutable(list, item);
+    itemFound = true;
+
+    return {
+      ...item,
+      actualUnitMinor,
+      purchasedAt,
+      updatedAt: purchasedAt,
+    };
+  });
+
+  if (!itemFound) {
+    throw new Error(`Shopping list item not found: ${itemId}`);
+  }
+
+  return {
+    ...list,
+    items,
+    updatedAt: purchasedAt,
+  };
+}
+
+export function markShoppingListItemUnpurchased(list: ShoppingList, itemId: string, updatedAt: string): ShoppingList {
+  assertShoppingListIsMutable(list);
+
+  if (!isValidTimestamp(updatedAt)) {
+    throw new Error('Updated timestamp is required.');
+  }
+
+  let itemFound = false;
+  const items = list.items.map((item) => {
+    if (item.id !== itemId) {
+      return item;
+    }
+
+    assertShoppingListItemIsMutable(list, item);
+    itemFound = true;
+
+    return {
+      ...item,
+      purchasedAt: null,
+      updatedAt,
+    };
+  });
+
+  if (!itemFound) {
+    throw new Error(`Shopping list item not found: ${itemId}`);
+  }
+
+  return {
+    ...list,
+    items,
+    updatedAt,
+  };
+}

--- a/src/lib/sqlite/bootstrap.test.ts
+++ b/src/lib/sqlite/bootstrap.test.ts
@@ -34,7 +34,8 @@ describe('createSQLiteBootstrap', () => {
     expect(openDatabaseAsync).toHaveBeenCalledTimes(1);
     expect(getFirstAsync).toHaveBeenCalledTimes(1);
     expect(execAsync).toHaveBeenCalledWith('PRAGMA journal_mode = WAL;');
+    expect(execAsync).toHaveBeenCalledWith('PRAGMA foreign_keys = ON;');
     expect(withTransactionAsync).toHaveBeenCalledTimes(1);
-    expect(execAsync).toHaveBeenCalledWith('PRAGMA user_version = 1;');
+    expect(execAsync).toHaveBeenCalledWith('PRAGMA user_version = 2;');
   });
 });

--- a/src/lib/sqlite/bootstrap.ts
+++ b/src/lib/sqlite/bootstrap.ts
@@ -20,6 +20,7 @@ export function createSQLiteBootstrap({
   const initializeDatabase = async () => {
     const database = await openDatabaseAsync(databaseName);
     await database.execAsync('PRAGMA journal_mode = WAL;');
+    await database.execAsync('PRAGMA foreign_keys = ON;');
 
     const currentVersionRow = await database.getFirstAsync<{ user_version: number }>(
       'PRAGMA user_version;'

--- a/src/lib/sqlite/migrations.test.ts
+++ b/src/lib/sqlite/migrations.test.ts
@@ -1,28 +1,113 @@
 import { describe, expect, it, jest } from '@jest/globals';
+import { unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
+import { createSQLiteBootstrap, type SQLiteBootstrapDependencies } from './bootstrap';
+import { createSQLiteShoppingListRepository } from './shopping-list-repository';
 import { SQLITE_DATABASE_VERSION, applySQLiteMigrations } from './migrations';
 
 type MockSQLiteDatabase = {
   execAsync: jest.MockedFunction<(sql: string) => Promise<void>>;
+  withExclusiveTransactionAsync?: (task: (database: MockSQLiteDatabase) => Promise<void>) => Promise<void>;
   withTransactionAsync: (task: () => Promise<void>) => Promise<void>;
 };
+
+type NodeSQLiteStatement = {
+  all: (...params: readonly unknown[]) => readonly Record<string, unknown>[];
+  get: (...params: readonly unknown[]) => Record<string, unknown> | undefined;
+  run: (...params: readonly unknown[]) => { changes: number; lastInsertRowid: number | bigint };
+};
+
+type NodeSQLiteNativeDatabase = {
+  close: () => void;
+  exec: (sql: string) => void;
+  prepare: (sql: string) => NodeSQLiteStatement;
+};
+
+type NodeSQLiteAdapter = {
+  closeAsync: () => Promise<void>;
+  execAsync: (sql: string) => Promise<void>;
+  getAllAsync: <T>(sql: string, ...params: readonly unknown[]) => Promise<readonly T[]>;
+  getFirstAsync: <T>(sql: string, ...params: readonly unknown[]) => Promise<T | undefined>;
+  runAsync: (sql: string, ...params: readonly unknown[]) => Promise<unknown>;
+  withExclusiveTransactionAsync: (task: (database: NodeSQLiteAdapter) => Promise<void>) => Promise<void>;
+  withTransactionAsync: (task: (database: NodeSQLiteAdapter) => Promise<void>) => Promise<void>;
+};
+
+async function createNodeSQLiteAdapter(databasePath: string): Promise<NodeSQLiteAdapter> {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { DatabaseSync } = require('node:sqlite') as {
+    DatabaseSync: new (path: string) => NodeSQLiteNativeDatabase;
+  };
+  const database = new DatabaseSync(databasePath);
+
+  const adapter: NodeSQLiteAdapter = {
+    closeAsync: async () => {
+      database.close();
+    },
+    execAsync: async (sql: string) => {
+      database.exec(sql);
+    },
+    getAllAsync: async <T>(sql: string, ...params: readonly unknown[]) => {
+      return database.prepare(sql).all(...params) as readonly T[];
+    },
+    getFirstAsync: async <T>(sql: string, ...params: readonly unknown[]) => {
+      return database.prepare(sql).get(...params) as T | undefined;
+    },
+    runAsync: async (sql: string, ...params: readonly unknown[]) => {
+      return database.prepare(sql).run(...params);
+    },
+    withExclusiveTransactionAsync: async (task: (database: NodeSQLiteAdapter) => Promise<void>) => {
+      database.exec('BEGIN');
+
+      try {
+        await task(adapter);
+        database.exec('COMMIT');
+      } catch (error) {
+        database.exec('ROLLBACK');
+        throw error;
+      }
+    },
+    withTransactionAsync: async (task: (database: NodeSQLiteAdapter) => Promise<void>) => {
+      database.exec('BEGIN');
+
+      try {
+        await task(adapter);
+        database.exec('COMMIT');
+      } catch (error) {
+        database.exec('ROLLBACK');
+        throw error;
+      }
+    },
+  };
+
+  return adapter;
+}
 
 describe('applySQLiteMigrations', () => {
   it('updates user_version inside the migration transaction', async () => {
     const execAsync: MockSQLiteDatabase['execAsync'] = jest
       .fn<(sql: string) => Promise<void>>()
       .mockResolvedValue(undefined);
+    const withExclusiveTransactionAsync = jest.fn(async (task: (database: MockSQLiteDatabase) => Promise<void>) => {
+      await task(database);
+    });
     const withTransactionAsync = jest.fn(async (task: () => Promise<void>) => {
       await task();
     });
     const database = {
       execAsync,
+      withExclusiveTransactionAsync,
       withTransactionAsync,
     } as unknown as MockSQLiteDatabase;
 
     await applySQLiteMigrations(database as never, 0);
 
-    expect(withTransactionAsync).toHaveBeenCalledTimes(1);
+    expect(withExclusiveTransactionAsync).toHaveBeenCalledTimes(1);
+    expect(execAsync).toHaveBeenCalledWith(expect.stringContaining('CREATE TABLE IF NOT EXISTS shopping_lists'));
+    expect(execAsync).toHaveBeenCalledWith(expect.stringContaining("currency_code TEXT NOT NULL CHECK (currency_code IN ('BRL', 'USD'))"));
+    expect(execAsync).toHaveBeenCalledWith(expect.stringContaining("ALTER TABLE shopping_lists ADD COLUMN status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'active', 'finalized'))"));
     expect(execAsync).toHaveBeenCalledWith(`PRAGMA user_version = ${SQLITE_DATABASE_VERSION};`);
   });
 
@@ -40,5 +125,127 @@ describe('applySQLiteMigrations', () => {
 
     expect(withTransactionAsync).not.toHaveBeenCalled();
     expect(execAsync).not.toHaveBeenCalled();
+  });
+
+  it('rolls back when a migration step fails before user_version advances', async () => {
+    const execAsync: MockSQLiteDatabase['execAsync'] = jest.fn(async (sql: string) => {
+      if (sql.includes('ALTER TABLE shopping_lists ADD COLUMN status')) {
+        throw new Error('migration failed');
+      }
+
+      return undefined;
+    });
+    const withTransactionAsync = jest.fn(async (task: () => Promise<void>) => {
+      await task();
+    });
+    const database = {
+      execAsync,
+      withTransactionAsync,
+    } as unknown as MockSQLiteDatabase;
+
+    await expect(applySQLiteMigrations(database as never, 1)).rejects.toThrow('migration failed');
+    expect(execAsync).not.toHaveBeenCalledWith(`PRAGMA user_version = ${SQLITE_DATABASE_VERSION};`);
+  });
+
+  it('upgrades a v1 on-disk database and reads the migrated rows back after reopening', async () => {
+    const databaseName = `migration-${Date.now()}-${Math.random().toString(36).slice(2)}.db`;
+    const databasePath = join(tmpdir(), databaseName);
+
+    try {
+      const legacyDatabase = await createNodeSQLiteAdapter(databasePath);
+
+      try {
+        await legacyDatabase.execAsync(`
+          PRAGMA journal_mode = WAL;
+          PRAGMA foreign_keys = ON;
+
+          CREATE TABLE IF NOT EXISTS shopping_lists (
+            id TEXT PRIMARY KEY NOT NULL,
+            name TEXT NOT NULL,
+            currency_code TEXT NOT NULL CHECK (currency_code IN ('BRL', 'USD')),
+            budget_minor INTEGER NOT NULL CHECK (budget_minor >= 0),
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+          );
+
+          CREATE TABLE IF NOT EXISTS shopping_list_items (
+            id TEXT PRIMARY KEY NOT NULL,
+            list_id TEXT NOT NULL REFERENCES shopping_lists(id) ON DELETE CASCADE,
+            name TEXT NOT NULL,
+            unit_code TEXT NOT NULL CHECK (unit_code IN ('piece', 'pack', 'kg', 'g', 'l', 'ml')),
+            quantity_milli INTEGER NOT NULL CHECK (quantity_milli > 0),
+            planned_unit_minor INTEGER NOT NULL CHECK (planned_unit_minor >= 0),
+            actual_unit_minor INTEGER,
+            purchased_at TEXT,
+            sort_order INTEGER NOT NULL CHECK (sort_order > 0),
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+          );
+
+          INSERT INTO shopping_lists (
+            id, name, currency_code, budget_minor, created_at, updated_at
+          ) VALUES (
+            'list-1', 'Weekly groceries', 'BRL', 4000, '2026-07-31T00:00:00.000Z', '2026-07-31T00:00:00.000Z'
+          );
+
+          INSERT INTO shopping_list_items (
+            id, list_id, name, unit_code, quantity_milli, planned_unit_minor, actual_unit_minor,
+            purchased_at, sort_order, created_at, updated_at
+          ) VALUES (
+            'item-1', 'list-1', 'Milk', 'piece', 2000, 600, 650,
+            '2026-07-31T00:00:00.000Z', 1, '2026-07-31T00:00:00.000Z', '2026-07-31T00:00:00.000Z'
+          );
+
+          PRAGMA user_version = 1;
+        `);
+      } finally {
+        await legacyDatabase.closeAsync();
+      }
+
+      const bootstrap = createSQLiteBootstrap({
+        databaseName,
+        openDatabaseAsync: (async () => createNodeSQLiteAdapter(databasePath)) as unknown as SQLiteBootstrapDependencies['openDatabaseAsync'],
+      });
+      const database = await bootstrap.ensureBootstrapped();
+      const repository = createSQLiteShoppingListRepository(database as never);
+      const list = await repository.get('list-1');
+      const userVersion = await database.getFirstAsync<{ user_version: number }>('PRAGMA user_version;');
+
+      expect(userVersion?.user_version).toBe(SQLITE_DATABASE_VERSION);
+      expect(list).toMatchObject({
+        budgetMinor: 4000,
+        currencyCode: 'BRL',
+        deletedAt: null,
+        finalizedAt: null,
+        id: 'list-1',
+        name: 'Weekly groceries',
+        status: 'draft',
+        items: [
+          {
+            actualUnitMinor: 650,
+            deletedAt: null,
+            id: 'item-1',
+            listId: 'list-1',
+            name: 'Milk',
+            plannedUnitMinor: 600,
+            purchasedAt: '2026-07-31T00:00:00.000Z',
+            quantityMilli: 2000,
+            sortOrder: 1,
+            unitCode: 'piece',
+          },
+        ],
+      });
+    } finally {
+      const walPath = `${databasePath}-wal`;
+      const shmPath = `${databasePath}-shm`;
+
+      for (const path of [databasePath, walPath, shmPath]) {
+        try {
+          unlinkSync(path);
+        } catch {
+          // Ignore cleanup races in tests.
+        }
+      }
+    }
   });
 });

--- a/src/lib/sqlite/migrations.ts
+++ b/src/lib/sqlite/migrations.ts
@@ -1,16 +1,69 @@
 import type { SQLiteDatabase } from 'expo-sqlite';
 
-export const SQLITE_DATABASE_VERSION = 1;
+export const SQLITE_DATABASE_VERSION = 2;
 
 export type SQLiteMigration = {
   version: number;
   up: (database: SQLiteDatabase) => Promise<void>;
 };
 
+type SQLiteMigratorDatabase = SQLiteDatabase & {
+  withExclusiveTransactionAsync?: (task: (txn: SQLiteDatabase) => Promise<void>) => Promise<void>;
+  withTransactionAsync: (task: () => Promise<void>) => Promise<void>;
+};
+
 const MIGRATIONS: readonly SQLiteMigration[] = [
   {
     version: 1,
-    up: async () => undefined,
+    up: async (database) => {
+      await database.execAsync(`
+        CREATE TABLE IF NOT EXISTS shopping_lists (
+          id TEXT PRIMARY KEY NOT NULL,
+          name TEXT NOT NULL,
+          currency_code TEXT NOT NULL CHECK (currency_code IN ('BRL', 'USD')),
+          budget_minor INTEGER NOT NULL CHECK (budget_minor >= 0),
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS shopping_list_items (
+          id TEXT PRIMARY KEY NOT NULL,
+          list_id TEXT NOT NULL REFERENCES shopping_lists(id) ON DELETE CASCADE,
+          name TEXT NOT NULL,
+          unit_code TEXT NOT NULL CHECK (unit_code IN ('piece', 'pack', 'kg', 'g', 'l', 'ml')),
+          quantity_milli INTEGER NOT NULL CHECK (quantity_milli > 0),
+          planned_unit_minor INTEGER NOT NULL CHECK (planned_unit_minor >= 0),
+          actual_unit_minor INTEGER CHECK (actual_unit_minor IS NULL OR actual_unit_minor >= 0),
+          purchased_at TEXT,
+          sort_order INTEGER NOT NULL CHECK (sort_order > 0),
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_shopping_list_items_list_id_sort_order
+          ON shopping_list_items(list_id, sort_order);
+      `);
+    },
+  },
+  {
+    version: 2,
+    up: async (database) => {
+      await database.execAsync(`
+        ALTER TABLE shopping_lists ADD COLUMN status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'active', 'finalized'));
+        ALTER TABLE shopping_lists ADD COLUMN finalized_at TEXT;
+        ALTER TABLE shopping_lists ADD COLUMN deleted_at TEXT;
+        ALTER TABLE shopping_list_items ADD COLUMN deleted_at TEXT;
+
+        CREATE INDEX IF NOT EXISTS idx_shopping_lists_status_deleted_at
+          ON shopping_lists(status, deleted_at);
+
+        CREATE INDEX IF NOT EXISTS idx_shopping_lists_deleted_at_updated_at
+          ON shopping_lists(deleted_at, updated_at);
+
+        CREATE INDEX IF NOT EXISTS idx_shopping_list_items_list_id_deleted_at_sort_order
+          ON shopping_list_items(list_id, deleted_at, sort_order);
+      `);
+    },
   },
 ];
 
@@ -19,15 +72,26 @@ export async function applySQLiteMigrations(database: SQLiteDatabase, currentVer
     return;
   }
 
-  await database.withTransactionAsync(async () => {
+  const runMigrations = async (transaction: SQLiteDatabase) => {
     for (const migration of MIGRATIONS) {
       if (migration.version <= currentVersion) {
         continue;
       }
 
-      await migration.up(database);
+      await migration.up(transaction);
     }
 
-    await database.execAsync(`PRAGMA user_version = ${SQLITE_DATABASE_VERSION};`);
+    await transaction.execAsync(`PRAGMA user_version = ${SQLITE_DATABASE_VERSION};`);
+  };
+
+  const migratorDatabase = database as SQLiteMigratorDatabase;
+
+  if (migratorDatabase.withExclusiveTransactionAsync !== undefined) {
+    await migratorDatabase.withExclusiveTransactionAsync(runMigrations);
+    return;
+  }
+
+  await migratorDatabase.withTransactionAsync(async () => {
+    await runMigrations(database);
   });
 }

--- a/src/lib/sqlite/shopping-list-repository.test.ts
+++ b/src/lib/sqlite/shopping-list-repository.test.ts
@@ -1,0 +1,477 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { createSQLiteShoppingListRepository, mapShoppingListItemRow, mapShoppingListRow } from './shopping-list-repository';
+import type { SQLiteShoppingListRepositoryDatabase } from './shopping-list-repository';
+
+type TransactionTask = (database: SQLiteShoppingListRepositoryDatabase) => Promise<void>;
+
+function createShoppingList(): Parameters<typeof mapShoppingListRow>[0] {
+  return {
+    budget_minor: 4000,
+    created_at: '2026-07-31T00:00:00.000Z',
+    currency_code: 'BRL',
+    id: 'list-1',
+    name: ' Weekly groceries ',
+    updated_at: '2026-07-31T00:00:00.000Z',
+  };
+}
+
+function createShoppingListItem(): Parameters<typeof mapShoppingListItemRow>[0] {
+  return {
+    actual_unit_minor: 650,
+    created_at: '2026-07-31T00:00:00.000Z',
+    id: 'item-1',
+    list_id: 'list-1',
+    name: ' Milk ',
+    planned_unit_minor: 600,
+    purchased_at: '2026-07-31T00:00:00.000Z',
+    quantity_milli: 2000,
+    sort_order: 1,
+    unit_code: 'piece',
+    updated_at: '2026-07-31T00:00:00.000Z',
+  };
+}
+
+describe('createSQLiteShoppingListRepository', () => {
+  it('filters deleted rows by default and maps legacy rows without losing currency or quantity data', async () => {
+    const getFirstAsync = jest.fn(async () => createShoppingList());
+    const getAllAsync = jest.fn(async () => [createShoppingListItem()]);
+    const database = {
+      getAllAsync,
+      getFirstAsync,
+      runAsync: jest.fn(async () => undefined),
+      withExclusiveTransactionAsync: jest.fn(async (task: TransactionTask) => task(database as never)),
+      withTransactionAsync: jest.fn(async (task: TransactionTask) => task(database as never)),
+    } as unknown as SQLiteShoppingListRepositoryDatabase;
+
+    const repository = createSQLiteShoppingListRepository(database);
+    const list = await repository.get('list-1');
+
+    expect(getFirstAsync).toHaveBeenCalledWith(expect.stringContaining('deleted_at IS NULL'), 'list-1');
+    expect(getAllAsync).toHaveBeenCalledWith(expect.stringContaining('deleted_at IS NULL'), 'list-1');
+    expect(list).toMatchObject({
+      budgetMinor: 4000,
+      currencyCode: 'BRL',
+      name: 'Weekly groceries',
+      status: 'draft',
+      items: [
+        {
+          actualUnitMinor: 650,
+          name: 'Milk',
+          plannedUnitMinor: 600,
+          quantityMilli: 2000,
+          unitCode: 'piece',
+        },
+      ],
+    });
+  });
+
+  it('preserves soft-deleted item rows when saving the current list graph', async () => {
+    const shoppingList = {
+      budgetMinor: 4000,
+      createdAt: '2026-07-31T00:00:00.000Z',
+      currencyCode: 'BRL' as const,
+      deletedAt: null,
+      finalizedAt: null,
+      id: 'list-1',
+      items: [
+        {
+          actualUnitMinor: 650,
+          createdAt: '2026-07-31T00:00:00.000Z',
+          deletedAt: null,
+          id: 'item-1',
+          listId: 'list-1',
+          name: 'Milk',
+          plannedUnitMinor: 600,
+          purchasedAt: '2026-07-31T00:00:00.000Z',
+          quantityMilli: 2000,
+          sortOrder: 1,
+          unitCode: 'piece' as const,
+          updatedAt: '2026-07-31T00:00:00.000Z',
+        },
+      ],
+      name: 'Weekly groceries',
+      status: 'draft' as const,
+      updatedAt: '2026-07-31T00:00:00.000Z',
+    };
+
+    const committedState = {
+      items: new Map<string, { deleted_at: string | null }>([['item-history', { deleted_at: '2026-07-30T00:00:00.000Z' }]]),
+      list: undefined as { currency_code: string; id: string } | undefined,
+    };
+    let draftState: typeof committedState | null = null;
+    const runAsync = jest.fn(async (sql: string, ...params: readonly unknown[]) => {
+      if (draftState === null) {
+        throw new Error('transaction not started');
+      }
+
+      const normalizedSql = sql.trim().replace(/\s+/g, ' ');
+
+      if (normalizedSql.startsWith('INSERT INTO shopping_lists')) {
+        draftState.list = {
+          currency_code: String(params[2]),
+          id: String(params[0]),
+        };
+      }
+
+      if (normalizedSql.startsWith('INSERT INTO shopping_list_items')) {
+        const itemId = String(params[0]);
+        draftState.items.set(itemId, { deleted_at: params[9] as string | null });
+      }
+
+      return undefined;
+    });
+    const database = {
+      getAllAsync: jest.fn(async () => []),
+      getFirstAsync: jest.fn(async () => undefined),
+      runAsync,
+      withExclusiveTransactionAsync: jest.fn(async (task: TransactionTask) => {
+        draftState = {
+          items: new Map(committedState.items),
+          list: committedState.list ? { ...committedState.list } : undefined,
+        };
+
+        try {
+          await task(database as never);
+          committedState.items = new Map(draftState.items);
+          committedState.list = draftState.list ? { ...draftState.list } : undefined;
+        } finally {
+          draftState = null;
+        }
+      }),
+      withTransactionAsync: jest.fn(async (task: TransactionTask) => task(database as never)),
+    } as unknown as SQLiteShoppingListRepositoryDatabase;
+
+    const repository = createSQLiteShoppingListRepository(database);
+
+    await repository.save(shoppingList);
+
+    expect(runAsync).not.toHaveBeenCalledWith(expect.stringContaining('DELETE FROM shopping_list_items'), expect.anything());
+    expect(committedState.items.has('item-history')).toBe(true);
+    expect(committedState.items.get('item-history')).toEqual({ deleted_at: '2026-07-30T00:00:00.000Z' });
+    expect(committedState.items.has('item-1')).toBe(true);
+  });
+
+  it('rejects invalid database rows before mapping them into domain models', async () => {
+    const getFirstAsync = jest.fn(async () => ({
+      budget_minor: -10,
+      created_at: '2026-07-31T00:00:00.000Z',
+      currency_code: 'EUR',
+      id: 'list-1',
+      name: 'Weekly groceries',
+      status: 'draft',
+      updated_at: '2026-07-31T00:00:00.000Z',
+    }));
+    const getAllAsync = jest.fn(async () => []);
+    const database = {
+      getAllAsync,
+      getFirstAsync,
+      runAsync: jest.fn(async () => undefined),
+      withExclusiveTransactionAsync: jest.fn(async (task: TransactionTask) => task(database as never)),
+      withTransactionAsync: jest.fn(async (task: TransactionTask) => task(database as never)),
+    } as unknown as SQLiteShoppingListRepositoryDatabase;
+
+    const repository = createSQLiteShoppingListRepository(database);
+
+    await expect(repository.get('list-1')).rejects.toThrow('Shopping list row');
+  });
+
+  it('rejects invalid item rows before mapping them into domain models', async () => {
+    const getFirstAsync = jest.fn(async () => ({
+      budget_minor: 4000,
+      created_at: '2026-07-31T00:00:00.000Z',
+      currency_code: 'BRL',
+      id: 'list-1',
+      name: 'Weekly groceries',
+      status: 'draft',
+      updated_at: '2026-07-31T00:00:00.000Z',
+    }));
+    const getAllAsync = jest.fn(async () => [
+      {
+        actual_unit_minor: -1,
+        created_at: '2026-07-31T00:00:00.000Z',
+        deleted_at: null,
+        id: 'item-1',
+        list_id: 'list-1',
+        name: 'Milk',
+        planned_unit_minor: 600,
+        purchased_at: null,
+        quantity_milli: 2000,
+        sort_order: 1,
+        unit_code: 'piece',
+        updated_at: '2026-07-31T00:00:00.000Z',
+      },
+    ]);
+    const database = {
+      getAllAsync,
+      getFirstAsync,
+      runAsync: jest.fn(async () => undefined),
+      withExclusiveTransactionAsync: jest.fn(async (task: TransactionTask) => task(database as never)),
+      withTransactionAsync: jest.fn(async (task: TransactionTask) => task(database as never)),
+    } as unknown as SQLiteShoppingListRepositoryDatabase;
+
+    const repository = createSQLiteShoppingListRepository(database);
+
+    await expect(repository.get('list-1')).rejects.toThrow('Shopping list item row');
+  });
+
+  it('saves the list graph atomically and rolls back on write failure', async () => {
+    const shoppingList = {
+      budgetMinor: 4000,
+      createdAt: '2026-07-31T00:00:00.000Z',
+      currencyCode: 'BRL' as const,
+      deletedAt: null,
+      finalizedAt: null,
+      id: 'list-1',
+      items: [
+        {
+          actualUnitMinor: 650,
+          createdAt: '2026-07-31T00:00:00.000Z',
+          deletedAt: null,
+          id: 'item-1',
+          listId: 'list-1',
+          name: 'Milk',
+          plannedUnitMinor: 600,
+          purchasedAt: '2026-07-31T00:00:00.000Z',
+          quantityMilli: 2000,
+          sortOrder: 1,
+          unitCode: 'piece' as const,
+          updatedAt: '2026-07-31T00:00:00.000Z',
+        },
+        {
+          actualUnitMinor: null,
+          createdAt: '2026-07-31T00:00:00.000Z',
+          deletedAt: null,
+          id: 'item-2',
+          listId: 'list-1',
+          name: 'Rice',
+          plannedUnitMinor: 2500,
+          purchasedAt: null,
+          quantityMilli: 1000,
+          sortOrder: 2,
+          unitCode: 'piece' as const,
+          updatedAt: '2026-07-31T00:00:00.000Z',
+        },
+      ],
+      name: 'Weekly groceries',
+      status: 'draft' as const,
+      updatedAt: '2026-07-31T00:00:00.000Z',
+    };
+
+    const committedState = {
+      items: [] as string[],
+      listIds: [] as string[],
+    };
+    let draftState: typeof committedState | null = null;
+    const runAsync = jest.fn(async (sql: string, ...params: readonly unknown[]) => {
+      if (draftState === null) {
+        throw new Error('transaction not started');
+      }
+
+      const normalizedSql = sql.trim().replace(/\s+/g, ' ');
+
+      if (normalizedSql.startsWith('INSERT INTO shopping_lists')) {
+        draftState.listIds = [String(params[0])];
+      }
+
+      if (normalizedSql.startsWith('INSERT INTO shopping_list_items')) {
+        const itemId = String(params[0]);
+        draftState.items = [...draftState.items, itemId];
+
+        if (itemId === 'item-2') {
+          throw new Error('write failed');
+        }
+      }
+
+      return undefined;
+    });
+    const database = {
+      getAllAsync: jest.fn(async () => []),
+      getFirstAsync: jest.fn(async () => undefined),
+      runAsync,
+      withExclusiveTransactionAsync: jest.fn(async (task: TransactionTask) => {
+        const snapshot = {
+          items: [...committedState.items],
+          listIds: [...committedState.listIds],
+        };
+        draftState = {
+          items: [...committedState.items],
+          listIds: [...committedState.listIds],
+        };
+
+        try {
+          await task(database as never);
+          committedState.items = [...draftState.items];
+          committedState.listIds = [...draftState.listIds];
+        } catch (error) {
+          committedState.items = snapshot.items;
+          committedState.listIds = snapshot.listIds;
+          throw error;
+        } finally {
+          draftState = null;
+        }
+      }),
+      withTransactionAsync: jest.fn(async (task: TransactionTask) => {
+        await task(database as never);
+      }),
+    } as unknown as SQLiteShoppingListRepositoryDatabase;
+
+    const repository = createSQLiteShoppingListRepository(database);
+
+    await expect(repository.save(shoppingList)).rejects.toThrow('write failed');
+    expect(committedState).toEqual({ items: [], listIds: [] });
+    expect(runAsync).toHaveBeenCalled();
+  });
+
+  it('prevents changing currency after persisted actual spending exists', async () => {
+    const getFirstAsync = jest.fn(async () => ({
+      budget_minor: 4000,
+      created_at: '2026-07-31T00:00:00.000Z',
+      currency_code: 'BRL',
+      deleted_at: null,
+      finalized_at: null,
+      id: 'list-1',
+      name: 'Weekly groceries',
+      status: 'draft',
+      updated_at: '2026-07-31T00:00:00.000Z',
+    }));
+    const getAllAsync = jest.fn(async () => [
+      {
+        actual_unit_minor: 650,
+        created_at: '2026-07-31T00:00:00.000Z',
+        deleted_at: '2026-07-31T00:00:00.000Z',
+        id: 'item-1',
+        list_id: 'list-1',
+        name: 'Milk',
+        planned_unit_minor: 600,
+        purchased_at: '2026-07-31T00:00:00.000Z',
+        quantity_milli: 2000,
+        sort_order: 1,
+        unit_code: 'piece',
+        updated_at: '2026-07-31T00:00:00.000Z',
+      },
+    ]);
+    const runAsync = jest.fn(async () => undefined);
+    const database = {
+      getAllAsync,
+      getFirstAsync,
+      runAsync,
+      withExclusiveTransactionAsync: jest.fn(async (task: TransactionTask) => task(database as never)),
+      withTransactionAsync: jest.fn(async (task: TransactionTask) => task(database as never)),
+    } as unknown as SQLiteShoppingListRepositoryDatabase;
+
+    const repository = createSQLiteShoppingListRepository(database);
+
+    await expect(
+      repository.save({
+        budgetMinor: 4000,
+        createdAt: '2026-07-31T00:00:00.000Z',
+        currencyCode: 'USD',
+        deletedAt: null,
+        finalizedAt: null,
+        id: 'list-1',
+        items: [
+          {
+            actualUnitMinor: null,
+            createdAt: '2026-07-31T00:00:00.000Z',
+            deletedAt: null,
+            id: 'item-2',
+            listId: 'list-1',
+            name: 'Rice',
+            plannedUnitMinor: 2500,
+            purchasedAt: null,
+            quantityMilli: 1000,
+            sortOrder: 1,
+            unitCode: 'piece',
+            updatedAt: '2026-07-31T00:00:00.000Z',
+          },
+        ],
+        name: 'Weekly groceries',
+        status: 'draft',
+        updatedAt: '2026-07-31T00:00:00.000Z',
+      })
+    ).rejects.toThrow('Cannot change the currency of a saved list with existing items or actual spending.');
+    expect(getFirstAsync).toHaveBeenCalledTimes(1);
+    expect(getAllAsync).toHaveBeenCalledTimes(1);
+    expect(runAsync).not.toHaveBeenCalled();
+  });
+
+  it('re-checks the saved list currency lock inside the exclusive write transaction', async () => {
+    let currencyCode = 'BRL';
+    const getFirstAsync = jest.fn(async () => ({
+      budget_minor: 4000,
+      created_at: '2026-07-31T00:00:00.000Z',
+      currency_code: currencyCode,
+      deleted_at: null,
+      finalized_at: null,
+      id: 'list-1',
+      name: 'Weekly groceries',
+      status: 'draft',
+      updated_at: '2026-07-31T00:00:00.000Z',
+    }));
+    const getAllAsync = jest.fn(async () => [
+      {
+        actual_unit_minor: null,
+        created_at: '2026-07-31T00:00:00.000Z',
+        deleted_at: null,
+        id: 'item-1',
+        list_id: 'list-1',
+        name: 'Milk',
+        planned_unit_minor: 600,
+        purchased_at: null,
+        quantity_milli: 2000,
+        sort_order: 1,
+        unit_code: 'piece',
+        updated_at: '2026-07-31T00:00:00.000Z',
+      },
+    ]);
+    const runAsync = jest.fn(async () => undefined);
+    const database = {
+      getAllAsync,
+      getFirstAsync,
+      runAsync,
+      withExclusiveTransactionAsync: jest.fn(async (task: TransactionTask) => {
+        currencyCode = 'USD';
+        await task(database as never);
+      }),
+      withTransactionAsync: jest.fn(async (task: TransactionTask) => task(database as never)),
+    } as unknown as SQLiteShoppingListRepositoryDatabase;
+
+    const repository = createSQLiteShoppingListRepository(database);
+
+    await expect(
+      repository.save({
+        budgetMinor: 4000,
+        createdAt: '2026-07-31T00:00:00.000Z',
+        currencyCode: 'BRL',
+        deletedAt: null,
+        finalizedAt: null,
+        id: 'list-1',
+        items: [
+          {
+            actualUnitMinor: null,
+            createdAt: '2026-07-31T00:00:00.000Z',
+            deletedAt: null,
+            id: 'item-2',
+            listId: 'list-1',
+            name: 'Rice',
+            plannedUnitMinor: 2500,
+            purchasedAt: null,
+            quantityMilli: 1000,
+            sortOrder: 1,
+            unitCode: 'piece',
+            updatedAt: '2026-07-31T00:00:00.000Z',
+          },
+        ],
+        name: 'Weekly groceries',
+        status: 'draft',
+        updatedAt: '2026-07-31T00:00:00.000Z',
+      })
+    ).rejects.toThrow('Cannot change the currency of a saved list with existing items or actual spending.');
+
+    expect(getFirstAsync).toHaveBeenCalledTimes(1);
+    expect(getAllAsync).toHaveBeenCalledTimes(1);
+    expect(runAsync).not.toHaveBeenCalled();
+    expect(database.withExclusiveTransactionAsync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/sqlite/shopping-list-repository.ts
+++ b/src/lib/sqlite/shopping-list-repository.ts
@@ -1,0 +1,354 @@
+import {
+  calculateShoppingListTotals,
+  isSupportedShoppingListUnitCode,
+  normalizeShoppingListName,
+  validateShoppingList,
+  validateShoppingListItem,
+  type ShoppingList,
+  type ShoppingListItem,
+  type ShoppingListStatus,
+} from '@/domain/shopping-list';
+import type { ShoppingListQuery, ShoppingListRepository } from '@/domain/shopping-list-repository';
+import type { SupportedCurrency } from '@/lib/localization/resolution';
+
+export type SQLiteShoppingListRepositoryDatabase = {
+  execAsync: (sql: string) => Promise<void>;
+  getAllAsync: <T>(sql: string, ...params: readonly unknown[]) => Promise<readonly T[]>;
+  getFirstAsync: <T>(sql: string, ...params: readonly unknown[]) => Promise<T | undefined>;
+  runAsync: (sql: string, ...params: readonly unknown[]) => Promise<unknown>;
+  withExclusiveTransactionAsync?: (
+    task: (database: SQLiteShoppingListRepositoryDatabase) => Promise<void>
+  ) => Promise<void>;
+  withTransactionAsync: (
+    task: (database: SQLiteShoppingListRepositoryDatabase) => Promise<void>
+  ) => Promise<void>;
+};
+
+type ShoppingListRow = {
+  budget_minor: number;
+  created_at: string;
+  currency_code: string;
+  deleted_at?: string | null;
+  finalized_at?: string | null;
+  id: string;
+  name: string;
+  status?: string | null;
+  updated_at: string;
+};
+
+type ShoppingListItemRow = {
+  actual_unit_minor: number | null;
+  created_at: string;
+  deleted_at?: string | null;
+  id: string;
+  list_id: string;
+  name: string;
+  planned_unit_minor: number;
+  purchased_at: string | null;
+  quantity_milli: number;
+  sort_order: number;
+  unit_code: string;
+  updated_at: string;
+};
+
+type TransactionTask = (database: SQLiteShoppingListRepositoryDatabase) => Promise<void>;
+
+type TransactionalDatabase = SQLiteShoppingListRepositoryDatabase & {
+  withExclusiveTransactionAsync?: (task: TransactionTask) => Promise<void>;
+};
+
+const SHOPPING_LIST_TABLE = 'shopping_lists';
+const SHOPPING_LIST_ITEM_TABLE = 'shopping_list_items';
+
+function formatValidationErrors(prefix: string, errors: readonly { field: string; message: string }[]): string {
+  return `${prefix}: ${errors.map((issue) => `${issue.field}: ${issue.message}`).join('; ')}`;
+}
+
+function validateRowOrThrow<T extends { id: string }>(
+  rowLabel: string,
+  validation:
+    | { success: true; value: T }
+    | { errors: readonly { field: string; message: string }[]; success: false }
+): T {
+  if (validation.success) {
+    return validation.value;
+  }
+
+  throw new Error(formatValidationErrors(`${rowLabel} row`, validation.errors));
+}
+
+function createStatusFilter(query?: ShoppingListQuery): { clause: string; values: readonly unknown[] } {
+  const statuses = query?.status;
+
+  if (statuses === undefined || statuses.length === 0) {
+    return { clause: '', values: [] };
+  }
+
+  const placeholders = statuses.map(() => '?').join(', ');
+  return {
+    clause: ` AND status IN (${placeholders})`,
+    values: statuses,
+  };
+}
+
+function buildDeletedFilter(includeDeleted: boolean | undefined): string {
+  return includeDeleted ? '' : ' AND deleted_at IS NULL';
+}
+
+function hasLockedPersistedCurrencyState(list: ShoppingList): boolean {
+  const hasNonDeletedItems = list.items.some((item) => item.deletedAt === null);
+  const hasActualSpending = list.items.some(
+    (item) => item.purchasedAt !== null && item.actualUnitMinor !== null && item.actualUnitMinor > 0
+  );
+
+  if (hasNonDeletedItems || hasActualSpending) {
+    return true;
+  }
+
+  return calculateShoppingListTotals(list).actualMinor > 0;
+}
+
+function mapShoppingListRow(row: ShoppingListRow): ShoppingList {
+  const shoppingList = {
+    budgetMinor: row.budget_minor,
+    createdAt: row.created_at,
+    currencyCode: row.currency_code as SupportedCurrency,
+    deletedAt: row.deleted_at ?? null,
+    finalizedAt: row.finalized_at ?? null,
+    id: row.id,
+    items: [],
+    name: normalizeShoppingListName(row.name),
+    status: (row.status ?? 'draft') as ShoppingListStatus,
+    updatedAt: row.updated_at,
+  };
+
+  return validateRowOrThrow('Shopping list', validateShoppingList(shoppingList));
+}
+
+function mapShoppingListItemRow(row: ShoppingListItemRow): ShoppingListItem {
+  if (!isSupportedShoppingListUnitCode(row.unit_code)) {
+    throw new Error(`Unsupported unit code: ${row.unit_code}`);
+  }
+
+  const shoppingListItem = {
+    actualUnitMinor: row.actual_unit_minor,
+    createdAt: row.created_at,
+    deletedAt: row.deleted_at ?? null,
+    id: row.id,
+    listId: row.list_id,
+    name: normalizeShoppingListName(row.name),
+    plannedUnitMinor: row.planned_unit_minor,
+    purchasedAt: row.purchased_at,
+    quantityMilli: row.quantity_milli,
+    sortOrder: row.sort_order,
+    unitCode: row.unit_code,
+    updatedAt: row.updated_at,
+  };
+
+  return validateRowOrThrow('Shopping list item', validateShoppingListItem(shoppingListItem));
+}
+
+function groupItemsByListId(items: readonly ShoppingListItem[]): ReadonlyMap<string, readonly ShoppingListItem[]> {
+  const grouped = new Map<string, ShoppingListItem[]>();
+
+  for (const item of items) {
+    const existing = grouped.get(item.listId) ?? [];
+    grouped.set(item.listId, [...existing, item]);
+  }
+
+  return grouped;
+}
+
+async function runInTransaction(
+  database: TransactionalDatabase,
+  task: TransactionTask
+): Promise<void> {
+  if (database.withExclusiveTransactionAsync !== undefined) {
+    await database.withExclusiveTransactionAsync(task);
+    return;
+  }
+
+  await database.withTransactionAsync(task);
+}
+
+async function loadShoppingLists(
+  database: SQLiteShoppingListRepositoryDatabase,
+  query?: ShoppingListQuery
+): Promise<readonly ShoppingList[]> {
+  const deletedFilter = buildDeletedFilter(query?.includeDeleted);
+  const statusFilter = createStatusFilter(query);
+  const rows = await database.getAllAsync<ShoppingListRow>(
+    `SELECT id, name, currency_code, budget_minor, status, finalized_at, deleted_at, created_at, updated_at
+     FROM ${SHOPPING_LIST_TABLE}
+     WHERE 1 = 1${deletedFilter}${statusFilter.clause}
+     ORDER BY updated_at DESC, created_at DESC, id DESC`,
+    ...statusFilter.values
+  );
+
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const listIds = rows.map((row) => row.id);
+  const itemDeletedFilter = buildDeletedFilter(query?.includeDeleted);
+  const itemRows = await database.getAllAsync<ShoppingListItemRow>(
+    `SELECT id, list_id, name, unit_code, quantity_milli, planned_unit_minor, actual_unit_minor,
+            purchased_at, sort_order, deleted_at, created_at, updated_at
+     FROM ${SHOPPING_LIST_ITEM_TABLE}
+     WHERE list_id IN (${listIds.map(() => '?').join(', ')})${itemDeletedFilter}
+     ORDER BY list_id, sort_order, created_at, id`,
+    ...listIds
+  );
+
+  const items = itemRows.map(mapShoppingListItemRow);
+  const itemsByListId = groupItemsByListId(items);
+
+  return rows.map((row) => ({
+    ...mapShoppingListRow(row),
+    items: itemsByListId.get(row.id) ?? [],
+  }));
+}
+
+async function loadShoppingListById(
+  database: SQLiteShoppingListRepositoryDatabase,
+  id: string,
+  query?: ShoppingListQuery
+): Promise<ShoppingList | null> {
+  const deletedFilter = buildDeletedFilter(query?.includeDeleted);
+  const listRow = await database.getFirstAsync<ShoppingListRow>(
+    `SELECT id, name, currency_code, budget_minor, status, finalized_at, deleted_at, created_at, updated_at
+     FROM ${SHOPPING_LIST_TABLE}
+     WHERE id = ?${deletedFilter}`,
+    id
+  );
+
+  if (listRow === undefined) {
+    return null;
+  }
+
+  const itemDeletedFilter = buildDeletedFilter(query?.includeDeleted);
+  const itemRows = await database.getAllAsync<ShoppingListItemRow>(
+    `SELECT id, list_id, name, unit_code, quantity_milli, planned_unit_minor, actual_unit_minor,
+            purchased_at, sort_order, deleted_at, created_at, updated_at
+     FROM ${SHOPPING_LIST_ITEM_TABLE}
+     WHERE list_id = ?${itemDeletedFilter}
+     ORDER BY sort_order, created_at, id`,
+    id
+  );
+
+  return {
+    ...mapShoppingListRow(listRow),
+    items: itemRows.map(mapShoppingListItemRow),
+  };
+}
+
+function buildListUpsertStatement(): string {
+  return `
+    INSERT INTO ${SHOPPING_LIST_TABLE} (
+      id, name, currency_code, budget_minor, status, finalized_at, deleted_at, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET
+      name = excluded.name,
+      currency_code = excluded.currency_code,
+      budget_minor = excluded.budget_minor,
+      status = excluded.status,
+      finalized_at = excluded.finalized_at,
+      deleted_at = excluded.deleted_at,
+      created_at = excluded.created_at,
+      updated_at = excluded.updated_at
+  `;
+}
+
+function buildItemUpsertStatement(): string {
+  return `
+    INSERT INTO ${SHOPPING_LIST_ITEM_TABLE} (
+      id, list_id, name, unit_code, quantity_milli, planned_unit_minor, actual_unit_minor,
+      purchased_at, sort_order, deleted_at, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET
+      list_id = excluded.list_id,
+      name = excluded.name,
+      unit_code = excluded.unit_code,
+      quantity_milli = excluded.quantity_milli,
+      planned_unit_minor = excluded.planned_unit_minor,
+      actual_unit_minor = excluded.actual_unit_minor,
+      purchased_at = excluded.purchased_at,
+      sort_order = excluded.sort_order,
+      deleted_at = excluded.deleted_at,
+      created_at = excluded.created_at,
+      updated_at = excluded.updated_at
+  `;
+}
+
+export function createSQLiteShoppingListRepository(
+  database: TransactionalDatabase
+): ShoppingListRepository {
+  return {
+    get: async (id, query) => loadShoppingListById(database, id, query),
+    list: async (query) => loadShoppingLists(database, query),
+    save: async (shoppingList) => {
+      const normalizedShoppingList = {
+        ...shoppingList,
+        items: shoppingList.items.map((item) => ({
+          ...item,
+          name: normalizeShoppingListName(item.name),
+        })),
+        name: normalizeShoppingListName(shoppingList.name),
+      };
+
+      const validation = validateShoppingList(normalizedShoppingList);
+
+      if (!validation.success) {
+        throw new Error(validation.errors.map((issue) => `${issue.field}: ${issue.message}`).join('; '));
+      }
+
+      await runInTransaction(database, async (transaction) => {
+        const persistedShoppingList = await loadShoppingListById(transaction, normalizedShoppingList.id, {
+          includeDeleted: true,
+        });
+
+        if (
+          persistedShoppingList !== null &&
+          persistedShoppingList.currencyCode !== normalizedShoppingList.currencyCode &&
+          hasLockedPersistedCurrencyState(persistedShoppingList)
+        ) {
+          throw new Error('Cannot change the currency of a saved list with existing items or actual spending.');
+        }
+
+        await transaction.runAsync(
+          buildListUpsertStatement(),
+          normalizedShoppingList.id,
+          normalizedShoppingList.name,
+          normalizedShoppingList.currencyCode,
+          normalizedShoppingList.budgetMinor,
+          normalizedShoppingList.status,
+          normalizedShoppingList.finalizedAt,
+          normalizedShoppingList.deletedAt,
+          normalizedShoppingList.createdAt,
+          normalizedShoppingList.updatedAt
+        );
+
+        for (const item of normalizedShoppingList.items) {
+          await transaction.runAsync(
+            buildItemUpsertStatement(),
+            item.id,
+            item.listId,
+            item.name,
+            item.unitCode,
+            item.quantityMilli,
+            item.plannedUnitMinor,
+            item.actualUnitMinor,
+            item.purchasedAt,
+            item.sortOrder,
+            item.deletedAt,
+            item.createdAt,
+            item.updatedAt
+          );
+        }
+      });
+    },
+  };
+}
+
+export { mapShoppingListItemRow, mapShoppingListRow };
+export { calculateShoppingListTotals } from '@/domain/shopping-list';


### PR DESCRIPTION
## Summary
- Adds money-safe, unit-aware domain types and use cases.
- Adds ordered SQLite migrations and transaction-safe repositories.
- Adds migration, upgrade, soft-delete, currency-lock, and atomic-write coverage.

## Validation
- `npm test -- --runInBand`
- `npm run lint`
- `npm run typecheck`