### PR TITLE
docs(v2): add agent implementation guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Cabe no Meu Bolso
+
+Offline-first grocery-budget app. V2 plans are the product contract; implementation guidance below does not replace them.
+
+## Commands
+
+```sh
+npm run start
+npm run android
+npm run ios
+npm run lint
+npm run test
+npm run typecheck
+npx expo-doctor@latest
+```
+
+## Non-negotiable rules
+
+- Build a clean Expo V2 app; do not upgrade or migrate the legacy Realm app.
+- Keep domain records in SQLite. Screens do not issue SQL; domain code does not import platform or persistence libraries.
+- Store money as safe integer minor units and quantities as safe integer `quantity_milli`; never use float totals.
+- Use transactional, ordered V2 migrations. Preserve V2 data and soft-deleted records.
+- Build UI through project-owned semantic tokens and adapters. Add explicit accessibility semantics.
+- Validate independently: automated tests, realistic migration fixtures, and review.
+- Check [V2 decisions](docs/v2/decisions-and-open-questions.md) before implementing gated behavior.
+
+## Load guidance by task
+
+Load only what the task needs: read a project local page for broad rules, read a local skill playbook for a focused implementation task, and load an external skill only for its named framework or tool trigger. See the [loading index](docs/agent-guidance/skill-loading.md).
+
+**Project local pages:** [architecture](docs/agent-guidance/architecture.md), [domain and persistence](docs/agent-guidance/domain-and-persistence.md), [UI and accessibility](docs/agent-guidance/ui-and-accessibility.md), [testing and validation](docs/agent-guidance/testing-and-validation.md).
+
+**Local skill playbooks:** [SQLite persistence](docs/agent-guidance/skills/sqlite-persistence.md), [UI adapter boundary](docs/agent-guidance/skills/ui-adapter-boundary.md).
+
+Start with the [V2 reading order](docs/v2/README.md).

--- a/docs/agent-guidance/architecture.md
+++ b/docs/agent-guidance/architecture.md
@@ -1,0 +1,30 @@
+# Architecture guidance
+
+Load for app structure, routes, state, repositories, native dependencies, or release-boundary work.
+
+## Keep the boundary
+
+```text
+Expo Router screen → controller/UI state → use case → repository port → SQLite adapter
+```
+
+- Keep domain types, rules, use cases, and repository ports free of Expo, SQLite, Zustand, and future-sync imports.
+- Let screens call use cases, never SQL. Let adapters return domain models, never database rows.
+- Keep SQLite as the domain source of truth. Zustand holds preferences and transient UI state only.
+- Add remote sync only as an adapter at the composition root; do not change calculation or repository contracts.
+
+```ts
+interface ShoppingListRepository {
+  get(id: string): Promise<ShoppingList | null>;
+  save(list: ShoppingList): Promise<void>;
+}
+```
+
+## Platform and release boundaries
+
+- Use Expo Router and the approved dependency catalog. Resolve Expo packages with `npx expo install`.
+- Isolate platform-only UI in `*.ios` and `*.android` adapters.
+- Treat web SQLite as alpha until separately validated.
+- A native dependency or config-plugin change requires a new native build; EAS Update ships compatible JS/assets only.
+
+Read [V2 architecture](../v2/architecture.md) before changing these boundaries. For persistence details, read [domain and persistence](./domain-and-persistence.md).

--- a/docs/agent-guidance/domain-and-persistence.md
+++ b/docs/agent-guidance/domain-and-persistence.md
@@ -1,0 +1,38 @@
+# Domain and persistence guidance
+
+Load for calculations, input parsing, SQLite schema/migrations, list lifecycle, trash, templates, or currency behavior.
+
+## Preserve the invariants
+
+- Persist `BRL`/`USD` with safe integer minor units. Format and parse only at the UI boundary.
+- Persist catalog `unit_code` values and safe integer `quantity_milli`; `quantity_milli` is thousandths of the selected unit, not money.
+- Calculate totals from non-deleted item records. Do not store derived totals as authoritative values.
+- Keep list currency independent of UI language. Never convert units, prices, or currencies in V2.
+- Reject values and calculations outside JavaScript's safe-integer range. Check operands and the multiplication result before rounding; use `bigint` or reject the operation rather than silently losing precision.
+
+```ts
+if (!Number.isSafeInteger(item.quantityMilli) ||
+    !Number.isSafeInteger(item.actualUnitMinor)) {
+  throw new RangeError('Amount is too large');
+}
+const product = item.quantityMilli * item.actualUnitMinor;
+if (!Number.isSafeInteger(product)) throw new RangeError('Amount is too large');
+const actualItemMinor = Math.round(product / 1000);
+if (!Number.isSafeInteger(actualItemMinor)) throw new RangeError('Amount is too large');
+```
+
+## Write safely
+
+- Parameterize SQL. Use a transaction for every multi-row mutation, including list-plus-items, currency locks, and purge cascades.
+- Apply ordered migrations through `PRAGMA user_version`; test empty and representative prior databases.
+- Soft-delete with `deleted_at`. Preserve item deletion state when a deleted parent list is restored.
+- Serialize concurrent writes through repository transactions.
+
+```ts
+await database.withTransactionAsync(async () => {
+  await lists.softDelete(listId, deletedAt);
+  await items.hideForDeletedList(listId);
+});
+```
+
+Check [V2 data and rules](../v2/data-and-rules.md) for formulas and lifecycle rules, and [open decisions](../v2/decisions-and-open-questions.md) before choosing unresolved behavior. Use [testing guidance](./testing-and-validation.md) for migration fixtures and boundary cases.

--- a/docs/agent-guidance/skill-loading.md
+++ b/docs/agent-guidance/skill-loading.md
@@ -1,0 +1,25 @@
+# Skill-loading index
+
+V2 documents are the product contract. Project local guidance interprets that contract for this repository. External skills add framework or tool expertise; neither overrides V2 or local guidance.
+
+## Load by trigger
+
+| When the task involves | Read this project local page | Then read this local skill playbook | Load an external skill only when relevant |
+|---|---|---|---|
+| Routes, app layers, state, native dependencies, updates | [Architecture](./architecture.md) | — | `expo-router`, `eas-update-insights`, or `eas-app-stores` for the named platform/release task |
+| Rules, money, quantities, SQLite, migrations, trash, templates | [Domain and persistence](./domain-and-persistence.md) | [SQLite persistence](./skills/sqlite-persistence.md) for schema, migration, or repository writes | `expo-data-fetching` only for network work; V2 has no backend/sync scope |
+| Screens, adapters, themes, forms, accessibility, motion | [UI and accessibility](./ui-and-accessibility.md) | [UI adapter boundary](./skills/ui-adapter-boundary.md) when adding or changing a control or platform exception | `expo-ui`, `expo-native-ui`, `animations`, or `gestures` for that specific UI technology |
+| Tests, fixtures, device/release checks, review | [Testing and validation](./testing-and-validation.md) | Relevant playbook only when validating its change | `qa-test-planner`, `agent-browser`, or `eas-simulator` for the requested validation method |
+| Writing or changing project guidance | This index and the affected page or playbook | — | `writing-clearly-and-concisely` or `agent-md-refactor` |
+
+Do not preload every page, playbook, or external skill. A local page gives broad project rules; a local skill playbook gives a repeatable task checklist; an external skill covers a named technology or tool.
+
+## Local-document convention
+
+- Put durable project-specific rules in `docs/agent-guidance/<topic>.md`, not in the root file.
+- Give each page a one-line load trigger, short imperative rules, one working example where useful, and source links to `docs/v2/`.
+- Add one row here when a new page has a distinct task trigger. Keep `AGENTS.md` limited to universal rules and links.
+- Put focused, repeatable project workflows in `docs/agent-guidance/skills/<task>.md`. Each playbook needs a load trigger, Do / Don't rules, validation checklist, and V2 source links.
+- Link local pages with relative paths. Do not copy the V2 product contract; point to its authoritative section.
+
+Before implementing gated behavior, read [V2 decisions](../v2/decisions-and-open-questions.md).

--- a/docs/agent-guidance/skills/sqlite-persistence.md
+++ b/docs/agent-guidance/skills/sqlite-persistence.md
@@ -1,0 +1,36 @@
+# SQLite persistence playbook
+
+Load when changing SQLite schema, migrations, repository mapping, or a multi-row persistence write.
+
+## Do
+
+- Keep screens out of SQL and map rows to domain models at the adapter boundary.
+- Store money and `quantity_milli` as safe integers. Reject unsafe operands or products before rounding; do not silently lose precision.
+- Apply ordered, transactional migrations through `PRAGMA user_version`.
+- Wrap every multi-row mutation, purge cascade, and currency-lock transition in one repository transaction.
+- Soft-delete with `deleted_at`; restoring a parent must preserve an item deleted before its parent.
+- Test empty and representative prior-schema database fixtures, including an injected write failure.
+
+```ts
+await database.withTransactionAsync(async () => {
+  await lists.setCurrency(listId, currencyCode);
+  await lists.lockCurrencyIfItemsExist(listId);
+});
+```
+
+## Don't
+
+- Do not issue SQL from screens or import SQLite into domain rules.
+- Do not use floating-point money or quantities, persist derived totals, or mix list currencies.
+- Do not change a list currency after non-deleted items or actual spending exist.
+- Do not make migrations non-transactional, skip prior fixtures, or hard-delete before expiry.
+
+## Validation checklist
+
+- [ ] Domain and repository tests cover safe-integer limits, rounding, and invalid input.
+- [ ] Fresh and each supported prior-schema fixture migrate successfully with records, currency, units, quantities, and soft deletes preserved.
+- [ ] An injected write failure leaves no partial rows.
+- [ ] Concurrent writes serialize, and currency locks remain correct.
+- [ ] Normal reads and totals exclude deleted records.
+
+Sources: [V2 data and rules](../../v2/data-and-rules.md), [Epic 3](../../v2/roadmap/03-domain-and-persistence.md), and [domain guidance](../domain-and-persistence.md).

--- a/docs/agent-guidance/skills/ui-adapter-boundary.md
+++ b/docs/agent-guidance/skills/ui-adapter-boundary.md
@@ -1,0 +1,34 @@
+# UI adapter-boundary playbook
+
+Load when adding or changing a control, semantic token, platform-specific UI capability, or accessibility behavior.
+
+## Do
+
+- Add feature UI through project-owned adapters and semantic tokens.
+- Put a missing universal capability behind a documented `*.ios`/`*.android` adapter.
+- Pass translated visible copy, labels, hints, validation, and announcements through the adapter API.
+- Specify accessibility semantics, 44×44 pt targets, focus behavior, contrast, dynamic type, and reduced motion.
+- Test theme resolution in Light, Dark, and System modes before feature screens depend on the adapter.
+
+```tsx
+<AppButton accessibilityLabel={t('list.save')} onPress={saveList}>
+  {t('list.save')}
+</AppButton>
+```
+
+## Don't
+
+- Do not import raw platform controls, SwiftUI/Compose APIs, or screen-specific colors into feature screens.
+- Do not leak UI adapters into domain or use-case code.
+- Do not use color alone for budget status or omit translated accessibility semantics.
+- Do not add a platform exception without documenting and isolating it.
+
+## Validation checklist
+
+- [ ] Feature code imports only project adapters and semantic tokens.
+- [ ] The adapter boundary and theme resolver have tests; a sample route works in Light, Dark, and System.
+- [ ] VoiceOver/TalkBack labels, hints, focus after mutation, and non-interrupting total announcements work in `pt-BR` and `en`.
+- [ ] Dynamic type, touch targets, contrast, reduced motion, and bilingual text expansion pass device review.
+- [ ] Any platform exception is documented and contained in `*.ios`/`*.android` code.
+
+Sources: [V2 design system](../../v2/design-system.md), [Epic 2](../../v2/roadmap/02-design-system-foundations.md), and [UI guidance](../ui-and-accessibility.md).

--- a/docs/agent-guidance/testing-and-validation.md
+++ b/docs/agent-guidance/testing-and-validation.md
@@ -1,0 +1,27 @@
+# Testing and validation guidance
+
+Load for tests, migration work, review, device checks, release preparation, or acceptance criteria.
+
+## Validate independently
+
+1. Test pure domain rules in isolation.
+2. Test repositories against empty and representative prior-schema fixtures.
+3. Run lint, tests, typecheck, and `npx expo-doctor@latest` when applicable.
+4. Review boundaries and behavior separately from the implementation author.
+
+```ts
+expect(calculateActualMinor({ quantityMilli: 1500, unitMinor: 200 }))
+  .toBe(300);
+```
+
+## Minimum coverage by change
+
+| Change | Verify |
+|---|---|
+| Money or quantity | Integer rounding, invalid input, PT/EN × BRL/USD formatting/parsing |
+| Migration | Empty DB, each supported prior fixture, rollback/error behavior, preserved soft deletes |
+| Multi-row write | Transactionality, concurrent-write serialization, currency-lock behavior |
+| UI | TalkBack/VoiceOver, dynamic type, touch target, focus, contrast, reduced motion, both languages |
+| Native/config dependency | Development build and rebuild requirement; never rely on Expo Go when unsupported |
+
+Use real migration fixtures, not only mocks. Check [V2 architecture](../v2/architecture.md) and [V2 data and rules](../v2/data-and-rules.md) for required behavior; check [V2 release guidance](../v2/implementation-handoff.md) before release work.

--- a/docs/agent-guidance/ui-and-accessibility.md
+++ b/docs/agent-guidance/ui-and-accessibility.md
@@ -1,0 +1,27 @@
+# UI and accessibility guidance
+
+Load for screens, components, themes, localization, forms, motion, or accessibility validation.
+
+## Use the shared UI boundary
+
+- Features use project-owned semantic tokens and adapters such as `AppButton`, `AppTextField`, and `AppSheet`.
+- Do not introduce raw platform controls, screen-specific colors, or direct SwiftUI/Compose APIs in feature screens.
+- Put missing platform capabilities behind documented `*.ios`/`*.android` adapters.
+
+```tsx
+<AppButton
+  accessibilityLabel={t('list.save')}
+  onPress={saveList}
+>
+  {t('list.save')}
+</AppButton>
+```
+
+## Make behavior explicit
+
+- Translate visible copy, labels, hints, validation, and announcements in `pt-BR` and `en`.
+- Preserve focus after mutations. Announce total and over-budget changes without interrupting entry.
+- Support dynamic type, 44×44 pt targets, visible focus, contrast, reduced motion, and bilingual text expansion.
+- Parse money and quantity from raw input with the explicit input locale. A locale never changes a list's currency.
+
+Read [V2 design system](../v2/design-system.md) for tokens and adapter requirements. Read [V2 data and rules](../v2/data-and-rules.md) before implementing monetary or quantity fields.


### PR DESCRIPTION
## Summary
- Adds a concise root `AGENTS.md` with V2 rules and task-based loading guidance.
- Adds local architecture, domain, UI, and validation guidance.
- Adds local SQLite-persistence and UI-adapter-boundary playbooks plus an external-skill trigger index.

## Validation
- Verified Markdown links.
- Ran `git diff --check`.