### PR TITLE
feat(ads): add safe monetization foundation

### DIFF
--- a/admob.config.d.ts
+++ b/admob.config.d.ts
@@ -1,0 +1,15 @@
+export declare const GOOGLE_MOBILE_ADS_TEST_APP_IDS: Readonly<{
+  android: 'ca-app-pub-3940256099942544~3347511713';
+  ios: 'ca-app-pub-3940256099942544~1458002511';
+}>;
+
+export declare const GOOGLE_MOBILE_ADS_USER_TRACKING_USAGE_DESCRIPTION: 'This identifier will be used to deliver personalized ads to you.';
+
+export type AdMobPluginConfig = Readonly<{
+  androidAppId: string;
+  delayAppMeasurementInit: true;
+  iosAppId: string;
+  userTrackingUsageDescription: string;
+}>;
+
+export declare function createAdMobPluginConfig(): AdMobPluginConfig;

--- a/admob.config.js
+++ b/admob.config.js
@@ -1,0 +1,22 @@
+const GOOGLE_MOBILE_ADS_TEST_APP_IDS = {
+  android: 'ca-app-pub-3940256099942544~3347511713',
+  ios: 'ca-app-pub-3940256099942544~1458002511',
+};
+
+const GOOGLE_MOBILE_ADS_USER_TRACKING_USAGE_DESCRIPTION =
+  'This identifier will be used to deliver personalized ads to you.';
+
+function createAdMobPluginConfig() {
+  return {
+    androidAppId: GOOGLE_MOBILE_ADS_TEST_APP_IDS.android,
+    delayAppMeasurementInit: true,
+    iosAppId: GOOGLE_MOBILE_ADS_TEST_APP_IDS.ios,
+    userTrackingUsageDescription: GOOGLE_MOBILE_ADS_USER_TRACKING_USAGE_DESCRIPTION,
+  };
+}
+
+module.exports = {
+  GOOGLE_MOBILE_ADS_TEST_APP_IDS,
+  GOOGLE_MOBILE_ADS_USER_TRACKING_USAGE_DESCRIPTION,
+  createAdMobPluginConfig,
+};

--- a/app.config.test.ts
+++ b/app.config.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from '@jest/globals';
+
+import appConfig from './app.config';
+
+describe('app config', () => {
+  it('evaluates in Node and wires the AdMob plugin with safe public values', () => {
+    const result = appConfig({
+      config: {
+        name: 'Cabe no Meu Bolso',
+        plugins: ['expo-router'],
+      },
+    });
+
+    expect(result.plugins).toEqual([
+      'expo-router',
+      [
+        'react-native-google-mobile-ads',
+        {
+          androidAppId: 'ca-app-pub-3940256099942544~3347511713',
+          delayAppMeasurementInit: true,
+          iosAppId: 'ca-app-pub-3940256099942544~1458002511',
+          userTrackingUsageDescription: 'This identifier will be used to deliver personalized ads to you.',
+        },
+      ],
+    ]);
+  });
+});

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,4 +1,4 @@
-import { createAdMobPluginConfig } from './src/config/admob';
+import { createAdMobPluginConfig } from './admob.config.js';
 
 type ExpoAppConfig = {
   plugins?: unknown[];

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,0 +1,18 @@
+import { createAdMobPluginConfig } from './src/config/admob';
+
+type ExpoAppConfig = {
+  plugins?: unknown[];
+  [key: string]: unknown;
+};
+
+type ConfigContext = {
+  config: ExpoAppConfig;
+};
+
+export default ({ config }: ConfigContext): ExpoAppConfig => ({
+  ...config,
+  plugins: [
+    ...(config.plugins ?? []),
+    ['react-native-google-mobile-ads', createAdMobPluginConfig()],
+  ],
+});

--- a/app.json
+++ b/app.json
@@ -42,7 +42,8 @@
         "react-native-google-mobile-ads",
         {
           "androidAppId": "ca-app-pub-3940256099942544~3347511713",
-          "delayAppMeasurementInit": true
+          "delayAppMeasurementInit": true,
+          "userTrackingUsageDescription": "This identifier will be used to deliver personalized ads to you."
         }
       ],
       "expo-tracking-transparency"

--- a/app.json
+++ b/app.json
@@ -42,8 +42,7 @@
         "react-native-google-mobile-ads",
         {
           "androidAppId": "ca-app-pub-3940256099942544~3347511713",
-          "iosAppId": "ca-app-pub-3940256099942544~1458002511",
-          "userTrackingUsageDescription": "This identifier helps deliver relevant ads when advertising is enabled."
+          "delayAppMeasurementInit": true
         }
       ],
       "expo-tracking-transparency"

--- a/app.json
+++ b/app.json
@@ -38,14 +38,6 @@
           "supportedLocales": ["pt-BR", "en"]
         }
       ],
-      [
-        "react-native-google-mobile-ads",
-        {
-          "androidAppId": "ca-app-pub-3940256099942544~3347511713",
-          "delayAppMeasurementInit": true,
-          "userTrackingUsageDescription": "This identifier will be used to deliver personalized ads to you."
-        }
-      ],
       "expo-tracking-transparency"
     ],
     "experiments": {

--- a/docs/agent-guidance/architecture.md
+++ b/docs/agent-guidance/architecture.md
@@ -24,6 +24,7 @@ interface ShoppingListRepository {
 
 - Use Expo Router and the approved dependency catalog. Resolve Expo packages with `npx expo install`.
 - Isolate platform-only UI in `*.ios` and `*.android` adapters.
+- When a native SDK needs an iOS App ID only to avoid a startup crash, commit the public test App ID, keep the iOS runtime boundary no-op, and document the release scope as Android-only until an explicit enablement decision exists.
 - Treat web SQLite as alpha until separately validated.
 - A native dependency or config-plugin change requires a new native build; EAS Update ships compatible JS/assets only.
 

--- a/docs/v2/architecture.md
+++ b/docs/v2/architecture.md
@@ -74,7 +74,7 @@ Later sync can add a remote adapter and a sync/outbox port at the composition ro
 
 Install `react-native-google-mobile-ads` now, but expose it only through `AdService`, entitlement, and a release feature flag that defaults **off**. The only V2 placements are an adaptive banner on Home after list content and an inline banner in a finalized Summary. Never render ads in the active shopping flow; no interstitial or rewarded ads are in V2. Do not add purchases or analytics.
 
-AdMob requires its config plugin, platform App IDs, consent before initialization, test IDs/non-production configuration in development, and an Expo development or release build—not Expo Go. Native dependency or plugin changes require a rebuild. Epic 2 supplies the `AdSlot` adapter boundary; Epic 8 adds placements only after Home and Summary exist. See [dependencies](./dependencies.md) and [roadmap Epic 8](./roadmap/08-monetization-and-operations.md).
+AdMob requires its config plugin, platform App IDs, consent before initialization, test IDs/non-production configuration in development, and an Expo development or release build—not Expo Go. The iOS config carries Google's public test App ID only so the native SDK starts cleanly; the iOS ad boundary remains a no-op until a future deliberate enablement path swaps it in. Android remains the release target. Native dependency or plugin changes require a rebuild. Epic 2 supplies the `AdSlot` adapter boundary; Epic 8 adds placements only after Home and Summary exist. See [dependencies](./dependencies.md) and [roadmap Epic 8](./roadmap/08-monetization-and-operations.md).
 
 ## Operational constraints
 

--- a/docs/v2/dependencies.md
+++ b/docs/v2/dependencies.md
@@ -34,7 +34,7 @@ SDK 57.0.0 uses React Native 0.86.0, React 19.2.3, and Node 22.13.x+. `react-nat
 ## Native configuration and builds
 
 - Add/configure the Router and localization plugins as implementation requires; supported native locales are `pt-BR` and `en`.
-- AdMob’s config plugin needs Android/iOS **App IDs**, not ad-unit IDs. Obtain consent before `mobileAds().initialize()`; request ATT on iOS where applicable.
+- AdMob’s config plugin needs Android/iOS **App IDs**, not ad-unit IDs. This V2 branch uses the public Google iOS test App ID only to satisfy the native startup requirement; the iOS ad boundary stays a no-op until ads are deliberately enabled there. Android remains the release target. Obtain consent before `mobileAds().initialize()`; request ATT on iOS where applicable in the future enabled path.
 - AdMob does not run in Expo Go. Test it with package `TestIds`/test devices in a development build; never click production ads during testing. Plugin, native-dependency, SDK, or App-ID changes require a rebuild.
 - Configure EAS Update only after choosing channels and a `runtimeVersion` policy. Updates are compatible only with matching native runtime; use a release build to test the full update path.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "react-i18next": "^17.0.11",
         "react-native": "0.86.2",
         "react-native-gesture-handler": "~2.32.0",
-        "react-native-google-mobile-ads": "^16.4.0",
+        "react-native-google-mobile-ads": "16.3.4",
         "react-native-reanimated": "4.5.1",
         "react-native-safe-area-context": "~5.7.0",
         "react-native-screens": "~4.26.0",
@@ -12292,9 +12292,9 @@
       }
     },
     "node_modules/react-native-google-mobile-ads": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/react-native-google-mobile-ads/-/react-native-google-mobile-ads-16.4.0.tgz",
-      "integrity": "sha512-I+H9huEO30XaNZ4InPLCZS2DsnbegGjWqFavJMFssDnm78OPJkAOodY6OSCsEtonq0pdG2YbhchhIuZmE427Mw==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/react-native-google-mobile-ads/-/react-native-google-mobile-ads-16.3.4.tgz",
+      "integrity": "sha512-UDwyymhXZ//AqQVTcnEGD6Nt2M14LNL332jwi9HEHBsGK+N6VKm+IOgsb/b26mtUHxHW+XrQBilbGtiENdrqTA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@iabtcf/core": "^1.5.6",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react-i18next": "^17.0.11",
     "react-native": "0.86.2",
     "react-native-gesture-handler": "~2.32.0",
-    "react-native-google-mobile-ads": "^16.4.0",
+    "react-native-google-mobile-ads": "16.3.4",
     "react-native-reanimated": "4.5.1",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "~4.26.0",

--- a/src/components/ui/ad-slot.test.tsx
+++ b/src/components/ui/ad-slot.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it } from '@jest/globals';
+import { Text } from 'react-native';
+import renderer, { act } from 'react-test-renderer';
+
+import { AdSlot } from './ad-slot';
+
+describe('AdSlot', () => {
+  it('renders nothing when ads are not eligible', () => {
+    let tree: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(
+        <AdSlot
+          eligibility={{
+            canRender: false,
+            consentInfo: null,
+            privacyOptionsRequired: false,
+            releaseEnabled: false,
+            reason: 'disabled-by-flag',
+            shouldUseTestAds: false,
+          }}
+        >
+          <Text>Ad</Text>
+        </AdSlot>
+      );
+    });
+
+    expect(tree!.toJSON()).toBeNull();
+  });
+
+  it('renders the provided content when eligible', () => {
+    let tree: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(
+        <AdSlot
+          eligibility={{
+            canRender: true,
+            consentInfo: null,
+            privacyOptionsRequired: false,
+            releaseEnabled: true,
+            reason: 'ready',
+            shouldUseTestAds: true,
+          }}
+        >
+          <Text>Ad</Text>
+        </AdSlot>
+      );
+    });
+
+    expect(tree!.toJSON()).not.toBeNull();
+  });
+});

--- a/src/components/ui/ad-slot.tsx
+++ b/src/components/ui/ad-slot.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+
+import type { AdSlotEligibility } from '@/lib/ads/ad-service';
+
+type AdSlotProps = {
+  children: ReactNode;
+  eligibility: AdSlotEligibility;
+  fallback?: ReactNode;
+};
+
+export function AdSlot({ children, eligibility, fallback = null }: AdSlotProps) {
+  if (!eligibility.canRender) {
+    return <>{fallback}</>;
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,6 +1,7 @@
 export { AppColumn } from './app-column';
 export { AppButton } from './app-button';
 export { AppHost } from './app-host';
+export { AdSlot } from './ad-slot';
 export { AppRow } from './app-row';
 export { AppSelect } from './app-select';
 export { AppSheet } from './app-sheet';

--- a/src/config/admob.test.ts
+++ b/src/config/admob.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  GOOGLE_MOBILE_ADS_TEST_APP_IDS,
+  GOOGLE_MOBILE_ADS_USER_TRACKING_USAGE_DESCRIPTION,
+  createAdMobPluginConfig,
+} from './admob';
+
+describe('AdMob app config', () => {
+  it('uses the public Google test App IDs and no production identifiers', () => {
+    const config = createAdMobPluginConfig();
+
+    expect(config).toEqual({
+      androidAppId: GOOGLE_MOBILE_ADS_TEST_APP_IDS.android,
+      delayAppMeasurementInit: true,
+      iosAppId: GOOGLE_MOBILE_ADS_TEST_APP_IDS.ios,
+      userTrackingUsageDescription: GOOGLE_MOBILE_ADS_USER_TRACKING_USAGE_DESCRIPTION,
+    });
+    expect(config.androidAppId).toContain('3940256099942544');
+    expect(config.iosAppId).toContain('3940256099942544');
+  });
+});

--- a/src/config/admob.ts
+++ b/src/config/admob.ts
@@ -1,0 +1,16 @@
+export const GOOGLE_MOBILE_ADS_TEST_APP_IDS = {
+  android: 'ca-app-pub-3940256099942544~3347511713',
+  ios: 'ca-app-pub-3940256099942544~1458002511',
+} as const;
+
+export const GOOGLE_MOBILE_ADS_USER_TRACKING_USAGE_DESCRIPTION =
+  'This identifier will be used to deliver personalized ads to you.';
+
+export function createAdMobPluginConfig() {
+  return {
+    androidAppId: GOOGLE_MOBILE_ADS_TEST_APP_IDS.android,
+    delayAppMeasurementInit: true,
+    iosAppId: GOOGLE_MOBILE_ADS_TEST_APP_IDS.ios,
+    userTrackingUsageDescription: GOOGLE_MOBILE_ADS_USER_TRACKING_USAGE_DESCRIPTION,
+  } as const;
+}

--- a/src/config/admob.ts
+++ b/src/config/admob.ts
@@ -1,16 +1,6 @@
-export const GOOGLE_MOBILE_ADS_TEST_APP_IDS = {
-  android: 'ca-app-pub-3940256099942544~3347511713',
-  ios: 'ca-app-pub-3940256099942544~1458002511',
-} as const;
-
-export const GOOGLE_MOBILE_ADS_USER_TRACKING_USAGE_DESCRIPTION =
-  'This identifier will be used to deliver personalized ads to you.';
-
-export function createAdMobPluginConfig() {
-  return {
-    androidAppId: GOOGLE_MOBILE_ADS_TEST_APP_IDS.android,
-    delayAppMeasurementInit: true,
-    iosAppId: GOOGLE_MOBILE_ADS_TEST_APP_IDS.ios,
-    userTrackingUsageDescription: GOOGLE_MOBILE_ADS_USER_TRACKING_USAGE_DESCRIPTION,
-  } as const;
-}
+export {
+  GOOGLE_MOBILE_ADS_TEST_APP_IDS,
+  GOOGLE_MOBILE_ADS_USER_TRACKING_USAGE_DESCRIPTION,
+  createAdMobPluginConfig,
+  type AdMobPluginConfig,
+} from '../../admob.config.js';

--- a/src/lib/ads/ad-request-configuration.ts
+++ b/src/lib/ads/ad-request-configuration.ts
@@ -1,0 +1,27 @@
+export type AdRequestConfiguration = {
+  testDeviceIdentifiers: string[];
+};
+
+export type ResolveAdRequestConfigurationInput = {
+  isDevelopment: boolean;
+  testDeviceIdentifiers?: readonly string[];
+};
+
+const DEVELOPMENT_TEST_DEVICE_IDS = ['EMULATOR'];
+
+function normalizeIdentifiers(identifiers: readonly string[]): string[] {
+  return [...new Set(identifiers.map((identifier) => identifier.trim()).filter(Boolean))];
+}
+
+export function resolveAdRequestConfiguration({
+  isDevelopment,
+  testDeviceIdentifiers = [],
+}: ResolveAdRequestConfigurationInput): AdRequestConfiguration {
+  if (!isDevelopment) {
+    return { testDeviceIdentifiers: [] };
+  }
+
+  return {
+    testDeviceIdentifiers: normalizeIdentifiers([...DEVELOPMENT_TEST_DEVICE_IDS, ...testDeviceIdentifiers]),
+  };
+}

--- a/src/lib/ads/ad-service.test.ts
+++ b/src/lib/ads/ad-service.test.ts
@@ -18,11 +18,6 @@ jest.mock('react-native-google-mobile-ads', () => ({
   default: jest.fn(),
 }));
 
-jest.mock('./ios-tracking', () => ({
-  __esModule: true,
-  requestIosTrackingAuthorization: jest.fn(async () => 'granted'),
-}));
-
 type AdServiceDependencies = NonNullable<Parameters<typeof createAdService>[0]>;
 
 function createConsentInfo(overrides: Partial<AdsConsentInfo> = {}): AdsConsentInfo {
@@ -36,13 +31,12 @@ function createConsentInfo(overrides: Partial<AdsConsentInfo> = {}): AdsConsentI
 }
 
 describe('ad service', () => {
-  it('defaults the release flag off and keeps disabled state side-effect free', async () => {
+  it('keeps iOS as a no-op boundary even when ads are enabled elsewhere', async () => {
     const gatherConsent = jest.fn();
     const getConsentInfo = jest.fn();
     const showPrivacyOptionsForm = jest.fn();
     const setRequestConfiguration = jest.fn(async (_configuration: { testDeviceIdentifiers: string[] }) => undefined);
     const initialize = jest.fn(async () => [] as never[]);
-    const requestTrackingAuthorization = jest.fn();
     const service = createAdService({
       adsConsent: {
         gatherConsent,
@@ -52,12 +46,13 @@ describe('ad service', () => {
       isDevelopment: true,
       mobileAdsFactory: (() => ({ initialize, setRequestConfiguration })) as unknown as AdServiceDependencies['mobileAdsFactory'],
       platformOS: 'ios',
-      requestTrackingAuthorization: requestTrackingAuthorization as unknown as AdServiceDependencies['requestTrackingAuthorization'],
+      releaseEnabled: true,
     });
 
     expect(DEFAULT_ADS_RELEASE_FLAG).toBe(false);
 
     const snapshot = await service.prepare();
+    const privacySnapshot = await service.requestPrivacyOptions();
 
     expect(snapshot.eligibility).toEqual(
       expect.objectContaining({
@@ -67,15 +62,15 @@ describe('ad service', () => {
         shouldUseTestAds: false,
       })
     );
+    expect(privacySnapshot).toBe(snapshot);
     expect(gatherConsent).not.toHaveBeenCalled();
     expect(getConsentInfo).not.toHaveBeenCalled();
     expect(showPrivacyOptionsForm).not.toHaveBeenCalled();
     expect(setRequestConfiguration).not.toHaveBeenCalled();
-    expect(requestTrackingAuthorization).not.toHaveBeenCalled();
     expect(initialize).not.toHaveBeenCalled();
   });
 
-  it('waits for consent before configuring requests, requests ATT only on iOS, and uses test devices in development', async () => {
+  it('waits for consent before configuring requests on Android and uses test devices in development', async () => {
     const calls: string[] = [];
     const consentInfo = createConsentInfo();
     const gatherConsent = jest.fn(async () => {
@@ -91,10 +86,6 @@ describe('ad service', () => {
       calls.push('initialize');
       return [];
     });
-    const requestTrackingAuthorization = jest.fn(async () => {
-      calls.push('att');
-      return 'granted' as const;
-    });
     const service = createAdService({
       adsConsent: {
         gatherConsent,
@@ -103,25 +94,23 @@ describe('ad service', () => {
       } as unknown as AdServiceDependencies['adsConsent'],
       isDevelopment: true,
       mobileAdsFactory: (() => ({ initialize, setRequestConfiguration })) as unknown as AdServiceDependencies['mobileAdsFactory'],
-      platformOS: 'ios',
+      platformOS: 'android',
       releaseEnabled: true,
-      requestTrackingAuthorization: requestTrackingAuthorization as unknown as AdServiceDependencies['requestTrackingAuthorization'],
       testDeviceIdentifiers: ['custom-device', 'EMULATOR'],
     });
 
     const snapshot = await service.prepare();
 
-    expect(calls).toEqual(['consent', 'request-configuration', 'att', 'initialize']);
+    expect(calls).toEqual(['consent', 'request-configuration', 'initialize']);
     expect(gatherConsent).toHaveBeenCalledWith({ testDeviceIdentifiers: ['EMULATOR', 'custom-device'] });
     expect(setRequestConfiguration).toHaveBeenCalledWith({ testDeviceIdentifiers: ['EMULATOR', 'custom-device'] });
     expect(getConsentInfo).not.toHaveBeenCalled();
     expect(showPrivacyOptionsForm).not.toHaveBeenCalled();
-    expect(requestTrackingAuthorization).toHaveBeenCalledTimes(1);
     expect(initialize).toHaveBeenCalledTimes(1);
     expect(snapshot.eligibility).toEqual(
       expect.objectContaining({ canRender: true, reason: 'ready', shouldUseTestAds: true })
     );
-    expect(snapshot.trackingAuthorizationStatus).toBe('granted');
+    expect(snapshot.trackingAuthorizationStatus).toBeNull();
   });
 
   it('surfaces privacy options before initialization when required', async () => {
@@ -148,6 +137,7 @@ describe('ad service', () => {
       } as unknown as AdServiceDependencies['adsConsent'],
       isDevelopment: false,
       mobileAdsFactory: (() => ({ initialize, setRequestConfiguration })) as unknown as AdServiceDependencies['mobileAdsFactory'],
+      platformOS: 'android',
       releaseEnabled: true,
     });
 

--- a/src/lib/ads/ad-service.test.ts
+++ b/src/lib/ads/ad-service.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { AdsConsentPrivacyOptionsRequirementStatus, type AdsConsentInfo } from 'react-native-google-mobile-ads';
+import { createAdService, DEFAULT_ADS_RELEASE_FLAG, resolveAdSlotEligibility } from './ad-service';
+import { resolveAdRequestConfiguration } from './ad-request-configuration';
+
+jest.mock('react-native-google-mobile-ads', () => ({
+  AdsConsent: {
+    gatherConsent: jest.fn(),
+    getConsentInfo: jest.fn(),
+    showPrivacyOptionsForm: jest.fn(),
+  },
+  AdsConsentPrivacyOptionsRequirementStatus: {
+    NOT_REQUIRED: 'NOT_REQUIRED',
+    REQUIRED: 'REQUIRED',
+  },
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('./ios-tracking', () => ({
+  __esModule: true,
+  requestIosTrackingAuthorization: jest.fn(async () => 'granted'),
+}));
+
+type AdServiceDependencies = NonNullable<Parameters<typeof createAdService>[0]>;
+
+function createConsentInfo(overrides: Partial<AdsConsentInfo> = {}): AdsConsentInfo {
+  return {
+    canRequestAds: true,
+    isConsentFormAvailable: true,
+    privacyOptionsRequirementStatus: AdsConsentPrivacyOptionsRequirementStatus.NOT_REQUIRED,
+    status: 'OBTAINED' as AdsConsentInfo['status'],
+    ...overrides,
+  };
+}
+
+describe('ad service', () => {
+  it('defaults the release flag off and keeps disabled state side-effect free', async () => {
+    const gatherConsent = jest.fn();
+    const getConsentInfo = jest.fn();
+    const showPrivacyOptionsForm = jest.fn();
+    const setRequestConfiguration = jest.fn(async (_configuration: { testDeviceIdentifiers: string[] }) => undefined);
+    const initialize = jest.fn(async () => [] as never[]);
+    const requestTrackingAuthorization = jest.fn();
+    const service = createAdService({
+      adsConsent: {
+        gatherConsent,
+        getConsentInfo,
+        showPrivacyOptionsForm,
+      } as unknown as AdServiceDependencies['adsConsent'],
+      isDevelopment: true,
+      mobileAdsFactory: (() => ({ initialize, setRequestConfiguration })) as unknown as AdServiceDependencies['mobileAdsFactory'],
+      platformOS: 'ios',
+      requestTrackingAuthorization: requestTrackingAuthorization as unknown as AdServiceDependencies['requestTrackingAuthorization'],
+    });
+
+    expect(DEFAULT_ADS_RELEASE_FLAG).toBe(false);
+
+    const snapshot = await service.prepare();
+
+    expect(snapshot.eligibility).toEqual(
+      expect.objectContaining({
+        canRender: false,
+        reason: 'disabled-by-flag',
+        releaseEnabled: false,
+        shouldUseTestAds: false,
+      })
+    );
+    expect(gatherConsent).not.toHaveBeenCalled();
+    expect(getConsentInfo).not.toHaveBeenCalled();
+    expect(showPrivacyOptionsForm).not.toHaveBeenCalled();
+    expect(setRequestConfiguration).not.toHaveBeenCalled();
+    expect(requestTrackingAuthorization).not.toHaveBeenCalled();
+    expect(initialize).not.toHaveBeenCalled();
+  });
+
+  it('waits for consent before configuring requests, requests ATT only on iOS, and uses test devices in development', async () => {
+    const calls: string[] = [];
+    const consentInfo = createConsentInfo();
+    const gatherConsent = jest.fn(async () => {
+      calls.push('consent');
+      return consentInfo;
+    });
+    const getConsentInfo = jest.fn();
+    const showPrivacyOptionsForm = jest.fn();
+    const setRequestConfiguration = jest.fn(async () => {
+      calls.push('request-configuration');
+    });
+    const initialize = jest.fn(async () => {
+      calls.push('initialize');
+      return [];
+    });
+    const requestTrackingAuthorization = jest.fn(async () => {
+      calls.push('att');
+      return 'granted' as const;
+    });
+    const service = createAdService({
+      adsConsent: {
+        gatherConsent,
+        getConsentInfo,
+        showPrivacyOptionsForm,
+      } as unknown as AdServiceDependencies['adsConsent'],
+      isDevelopment: true,
+      mobileAdsFactory: (() => ({ initialize, setRequestConfiguration })) as unknown as AdServiceDependencies['mobileAdsFactory'],
+      platformOS: 'ios',
+      releaseEnabled: true,
+      requestTrackingAuthorization: requestTrackingAuthorization as unknown as AdServiceDependencies['requestTrackingAuthorization'],
+      testDeviceIdentifiers: ['custom-device', 'EMULATOR'],
+    });
+
+    const snapshot = await service.prepare();
+
+    expect(calls).toEqual(['consent', 'request-configuration', 'att', 'initialize']);
+    expect(gatherConsent).toHaveBeenCalledWith({ testDeviceIdentifiers: ['EMULATOR', 'custom-device'] });
+    expect(setRequestConfiguration).toHaveBeenCalledWith({ testDeviceIdentifiers: ['EMULATOR', 'custom-device'] });
+    expect(getConsentInfo).not.toHaveBeenCalled();
+    expect(showPrivacyOptionsForm).not.toHaveBeenCalled();
+    expect(requestTrackingAuthorization).toHaveBeenCalledTimes(1);
+    expect(initialize).toHaveBeenCalledTimes(1);
+    expect(snapshot.eligibility).toEqual(
+      expect.objectContaining({ canRender: true, reason: 'ready', shouldUseTestAds: true })
+    );
+    expect(snapshot.trackingAuthorizationStatus).toBe('granted');
+  });
+
+  it('surfaces privacy options before initialization when required', async () => {
+    const gatherConsent = jest.fn(async () =>
+      createConsentInfo({
+        canRequestAds: false,
+        privacyOptionsRequirementStatus: AdsConsentPrivacyOptionsRequirementStatus.REQUIRED,
+      })
+    );
+    const getConsentInfo = jest.fn();
+    const showPrivacyOptionsForm = jest.fn(async () =>
+      createConsentInfo({
+        canRequestAds: true,
+        privacyOptionsRequirementStatus: AdsConsentPrivacyOptionsRequirementStatus.NOT_REQUIRED,
+      })
+    );
+    const setRequestConfiguration = jest.fn(async (_configuration: { testDeviceIdentifiers: string[] }) => undefined);
+    const initialize = jest.fn(async () => [] as never[]);
+    const service = createAdService({
+      adsConsent: {
+        gatherConsent,
+        getConsentInfo,
+        showPrivacyOptionsForm,
+      } as unknown as AdServiceDependencies['adsConsent'],
+      isDevelopment: false,
+      mobileAdsFactory: (() => ({ initialize, setRequestConfiguration })) as unknown as AdServiceDependencies['mobileAdsFactory'],
+      releaseEnabled: true,
+    });
+
+    const snapshot = await service.prepare();
+
+    expect(gatherConsent).toHaveBeenCalledTimes(1);
+    expect(showPrivacyOptionsForm).toHaveBeenCalledTimes(1);
+    expect(setRequestConfiguration).toHaveBeenCalledWith({ testDeviceIdentifiers: [] });
+    expect(initialize).toHaveBeenCalledTimes(1);
+    expect(snapshot.eligibility).toEqual(
+      expect.objectContaining({ canRender: true, privacyOptionsRequired: false, reason: 'ready' })
+    );
+  });
+
+  it('keeps the eligibility boundary pure', () => {
+    expect(
+      resolveAdSlotEligibility({
+        consentInfo: createConsentInfo({ canRequestAds: false }),
+        isDevelopment: false,
+        releaseEnabled: true,
+      })
+    ).toEqual(
+      expect.objectContaining({
+        canRender: false,
+        reason: 'consent-required',
+        shouldUseTestAds: false,
+      })
+    );
+
+    expect(
+      resolveAdRequestConfiguration({ isDevelopment: false, testDeviceIdentifiers: ['EMULATOR'] })
+    ).toEqual({ testDeviceIdentifiers: [] });
+    expect(
+      resolveAdRequestConfiguration({ isDevelopment: true, testDeviceIdentifiers: ['EMULATOR', 'qa-device'] })
+    ).toEqual({ testDeviceIdentifiers: ['EMULATOR', 'qa-device'] });
+  });
+});

--- a/src/lib/ads/ad-service.ts
+++ b/src/lib/ads/ad-service.ts
@@ -8,7 +8,6 @@ import {
 import mobileAds from 'react-native-google-mobile-ads';
 
 import { resolveAdRequestConfiguration } from './ad-request-configuration';
-import { requestIosTrackingAuthorization, type TrackingAuthorizationStatus } from './ios-tracking';
 
 export const DEFAULT_ADS_RELEASE_FLAG = false;
 
@@ -26,7 +25,7 @@ export type AdSlotEligibility = {
 export type AdServiceSnapshot = {
   eligibility: AdSlotEligibility;
   initialized: boolean;
-  trackingAuthorizationStatus: TrackingAuthorizationStatus | null;
+  trackingAuthorizationStatus: null;
 };
 
 type AdsConsentClient = Pick<
@@ -41,7 +40,6 @@ type AdServiceDependencies = {
   mobileAdsFactory?: typeof mobileAds;
   platformOS?: typeof Platform.OS;
   releaseEnabled?: boolean;
-  requestTrackingAuthorization?: typeof requestIosTrackingAuthorization;
   testDeviceIdentifiers?: readonly string[];
 };
 
@@ -50,6 +48,20 @@ type AdService = {
   requestPrivacyOptions: () => Promise<AdServiceSnapshot>;
   getSnapshot: () => AdServiceSnapshot | null;
 };
+
+function createDisabledSnapshot(): AdServiceSnapshot {
+  return createSnapshot(
+    {
+      canRender: false,
+      consentInfo: null,
+      privacyOptionsRequired: false,
+      releaseEnabled: false,
+      reason: 'disabled-by-flag',
+      shouldUseTestAds: false,
+    },
+    null
+  );
+}
 
 function buildEligibility({
   consentInfo,
@@ -96,7 +108,7 @@ function buildEligibility({
   };
 }
 
-function createSnapshot(eligibility: AdSlotEligibility, trackingAuthorizationStatus: TrackingAuthorizationStatus | null): AdServiceSnapshot {
+function createSnapshot(eligibility: AdSlotEligibility, trackingAuthorizationStatus: null): AdServiceSnapshot {
   return {
     eligibility,
     initialized: eligibility.canRender,
@@ -105,29 +117,36 @@ function createSnapshot(eligibility: AdSlotEligibility, trackingAuthorizationSta
 }
 
 export function createAdService(dependencies: AdServiceDependencies = {}): AdService {
-  const adsConsent = dependencies.adsConsent ?? AdsConsent;
   const isDevelopment = dependencies.isDevelopment ?? __DEV__;
-  const mobileAdsClientFactory = dependencies.mobileAdsFactory ?? mobileAds;
   const platformOS = dependencies.platformOS ?? Platform.OS;
   const releaseEnabled = dependencies.releaseEnabled ?? DEFAULT_ADS_RELEASE_FLAG;
-  const requestTrackingAuthorization =
-    dependencies.requestTrackingAuthorization ?? requestIosTrackingAuthorization;
-  const testDeviceIdentifiers = dependencies.testDeviceIdentifiers ?? [];
 
   let snapshot: AdServiceSnapshot | null = null;
 
-  const markSnapshot = (
-    consentInfo: AdsConsentInfo | null,
-    trackingAuthorizationStatus: TrackingAuthorizationStatus | null
-  ): AdServiceSnapshot => {
+  if (platformOS === 'ios') {
+    const disabledSnapshot = createDisabledSnapshot();
+    snapshot = disabledSnapshot;
+
+    return {
+      getSnapshot: () => snapshot,
+      prepare: async () => disabledSnapshot,
+      requestPrivacyOptions: async () => disabledSnapshot,
+    };
+  }
+
+  const adsConsent = dependencies.adsConsent ?? AdsConsent;
+  const mobileAdsClientFactory = dependencies.mobileAdsFactory ?? mobileAds;
+  const testDeviceIdentifiers = dependencies.testDeviceIdentifiers ?? [];
+
+  const markSnapshot = (consentInfo: AdsConsentInfo | null): AdServiceSnapshot => {
     const eligibility = buildEligibility({ consentInfo, isDevelopment, releaseEnabled });
-    snapshot = createSnapshot(eligibility, trackingAuthorizationStatus);
+    snapshot = createSnapshot(eligibility, null);
     return snapshot;
   };
 
   const initialize = async (): Promise<AdServiceSnapshot> => {
     if (!releaseEnabled) {
-      return markSnapshot(null, null);
+      return markSnapshot(null);
     }
 
     let consentInfo: AdsConsentInfo;
@@ -149,7 +168,7 @@ export function createAdService(dependencies: AdServiceDependencies = {}): AdSer
     }
 
     if (!consentInfo.canRequestAds) {
-      return markSnapshot(consentInfo, null);
+      return markSnapshot(consentInfo);
     }
 
     const requestConfiguration = resolveAdRequestConfiguration({
@@ -161,15 +180,9 @@ export function createAdService(dependencies: AdServiceDependencies = {}): AdSer
 
     await mobileAdsClient.setRequestConfiguration(requestConfiguration);
 
-    let trackingAuthorizationStatus: TrackingAuthorizationStatus | null = null;
-
-    if (platformOS === 'ios') {
-      trackingAuthorizationStatus = await requestTrackingAuthorization();
-    }
-
     await mobileAdsClient.initialize();
 
-    return markSnapshot(consentInfo, trackingAuthorizationStatus);
+    return markSnapshot(consentInfo);
   };
 
   return {
@@ -177,17 +190,17 @@ export function createAdService(dependencies: AdServiceDependencies = {}): AdSer
     prepare: initialize,
     requestPrivacyOptions: async () => {
       if (!releaseEnabled) {
-        return markSnapshot(null, null);
+        return markSnapshot(null);
       }
 
       const consentInfo = await adsConsent.getConsentInfo();
 
       if (consentInfo.privacyOptionsRequirementStatus !== AdsConsentPrivacyOptionsRequirementStatus.REQUIRED) {
-        return markSnapshot(consentInfo, snapshot?.trackingAuthorizationStatus ?? null);
+        return markSnapshot(consentInfo);
       }
 
       const updatedConsentInfo = await adsConsent.showPrivacyOptionsForm();
-      return markSnapshot(updatedConsentInfo, snapshot?.trackingAuthorizationStatus ?? null);
+      return markSnapshot(updatedConsentInfo);
     },
   };
 }

--- a/src/lib/ads/ad-service.ts
+++ b/src/lib/ads/ad-service.ts
@@ -1,0 +1,195 @@
+import { Platform } from 'react-native';
+import {
+  AdsConsent,
+  AdsConsentPrivacyOptionsRequirementStatus,
+  type AdsConsentInfo,
+  type AdsConsentInfoOptions,
+} from 'react-native-google-mobile-ads';
+import mobileAds from 'react-native-google-mobile-ads';
+
+import { resolveAdRequestConfiguration } from './ad-request-configuration';
+import { requestIosTrackingAuthorization, type TrackingAuthorizationStatus } from './ios-tracking';
+
+export const DEFAULT_ADS_RELEASE_FLAG = false;
+
+export type AdEligibilityReason = 'disabled-by-flag' | 'consent-required' | 'privacy-options-required' | 'ready';
+
+export type AdSlotEligibility = {
+  canRender: boolean;
+  consentInfo: AdsConsentInfo | null;
+  privacyOptionsRequired: boolean;
+  releaseEnabled: boolean;
+  reason: AdEligibilityReason;
+  shouldUseTestAds: boolean;
+};
+
+export type AdServiceSnapshot = {
+  eligibility: AdSlotEligibility;
+  initialized: boolean;
+  trackingAuthorizationStatus: TrackingAuthorizationStatus | null;
+};
+
+type AdsConsentClient = Pick<
+  typeof AdsConsent,
+  'gatherConsent' | 'getConsentInfo' | 'showPrivacyOptionsForm'
+>;
+
+type AdServiceDependencies = {
+  adsConsent?: AdsConsentClient;
+  consentOptions?: AdsConsentInfoOptions;
+  isDevelopment?: boolean;
+  mobileAdsFactory?: typeof mobileAds;
+  platformOS?: typeof Platform.OS;
+  releaseEnabled?: boolean;
+  requestTrackingAuthorization?: typeof requestIosTrackingAuthorization;
+  testDeviceIdentifiers?: readonly string[];
+};
+
+type AdService = {
+  prepare: () => Promise<AdServiceSnapshot>;
+  requestPrivacyOptions: () => Promise<AdServiceSnapshot>;
+  getSnapshot: () => AdServiceSnapshot | null;
+};
+
+function buildEligibility({
+  consentInfo,
+  isDevelopment,
+  releaseEnabled,
+}: {
+  consentInfo: AdsConsentInfo | null;
+  isDevelopment: boolean;
+  releaseEnabled: boolean;
+}): AdSlotEligibility {
+  if (!releaseEnabled) {
+    return {
+      canRender: false,
+      consentInfo,
+      privacyOptionsRequired: false,
+      releaseEnabled,
+      reason: 'disabled-by-flag',
+      shouldUseTestAds: false,
+    };
+  }
+
+  if (consentInfo === null || !consentInfo.canRequestAds) {
+    const privacyOptionsRequired =
+      consentInfo?.privacyOptionsRequirementStatus === AdsConsentPrivacyOptionsRequirementStatus.REQUIRED;
+
+    return {
+      canRender: false,
+      consentInfo,
+      privacyOptionsRequired,
+      releaseEnabled,
+      reason: privacyOptionsRequired ? 'privacy-options-required' : 'consent-required',
+      shouldUseTestAds: isDevelopment,
+    };
+  }
+
+  return {
+    canRender: true,
+    consentInfo,
+    privacyOptionsRequired:
+      consentInfo.privacyOptionsRequirementStatus === AdsConsentPrivacyOptionsRequirementStatus.REQUIRED,
+    releaseEnabled,
+    reason: 'ready',
+    shouldUseTestAds: isDevelopment,
+  };
+}
+
+function createSnapshot(eligibility: AdSlotEligibility, trackingAuthorizationStatus: TrackingAuthorizationStatus | null): AdServiceSnapshot {
+  return {
+    eligibility,
+    initialized: eligibility.canRender,
+    trackingAuthorizationStatus,
+  };
+}
+
+export function createAdService(dependencies: AdServiceDependencies = {}): AdService {
+  const adsConsent = dependencies.adsConsent ?? AdsConsent;
+  const isDevelopment = dependencies.isDevelopment ?? __DEV__;
+  const mobileAdsClientFactory = dependencies.mobileAdsFactory ?? mobileAds;
+  const platformOS = dependencies.platformOS ?? Platform.OS;
+  const releaseEnabled = dependencies.releaseEnabled ?? DEFAULT_ADS_RELEASE_FLAG;
+  const requestTrackingAuthorization =
+    dependencies.requestTrackingAuthorization ?? requestIosTrackingAuthorization;
+  const testDeviceIdentifiers = dependencies.testDeviceIdentifiers ?? [];
+
+  let snapshot: AdServiceSnapshot | null = null;
+
+  const markSnapshot = (
+    consentInfo: AdsConsentInfo | null,
+    trackingAuthorizationStatus: TrackingAuthorizationStatus | null
+  ): AdServiceSnapshot => {
+    const eligibility = buildEligibility({ consentInfo, isDevelopment, releaseEnabled });
+    snapshot = createSnapshot(eligibility, trackingAuthorizationStatus);
+    return snapshot;
+  };
+
+  const initialize = async (): Promise<AdServiceSnapshot> => {
+    if (!releaseEnabled) {
+      return markSnapshot(null, null);
+    }
+
+    let consentInfo: AdsConsentInfo;
+
+    try {
+      consentInfo = await adsConsent.gatherConsent({
+        ...dependencies.consentOptions,
+        testDeviceIdentifiers: resolveAdRequestConfiguration({
+          isDevelopment,
+          testDeviceIdentifiers,
+        }).testDeviceIdentifiers,
+      });
+    } catch {
+      consentInfo = await adsConsent.getConsentInfo();
+    }
+
+    if (consentInfo.privacyOptionsRequirementStatus === AdsConsentPrivacyOptionsRequirementStatus.REQUIRED) {
+      consentInfo = await adsConsent.showPrivacyOptionsForm();
+    }
+
+    if (!consentInfo.canRequestAds) {
+      return markSnapshot(consentInfo, null);
+    }
+
+    const requestConfiguration = resolveAdRequestConfiguration({
+      isDevelopment,
+      testDeviceIdentifiers,
+    });
+
+    const mobileAdsClient = mobileAdsClientFactory();
+
+    await mobileAdsClient.setRequestConfiguration(requestConfiguration);
+
+    let trackingAuthorizationStatus: TrackingAuthorizationStatus | null = null;
+
+    if (platformOS === 'ios') {
+      trackingAuthorizationStatus = await requestTrackingAuthorization();
+    }
+
+    await mobileAdsClient.initialize();
+
+    return markSnapshot(consentInfo, trackingAuthorizationStatus);
+  };
+
+  return {
+    getSnapshot: () => snapshot,
+    prepare: initialize,
+    requestPrivacyOptions: async () => {
+      if (!releaseEnabled) {
+        return markSnapshot(null, null);
+      }
+
+      const consentInfo = await adsConsent.getConsentInfo();
+
+      if (consentInfo.privacyOptionsRequirementStatus !== AdsConsentPrivacyOptionsRequirementStatus.REQUIRED) {
+        return markSnapshot(consentInfo, snapshot?.trackingAuthorizationStatus ?? null);
+      }
+
+      const updatedConsentInfo = await adsConsent.showPrivacyOptionsForm();
+      return markSnapshot(updatedConsentInfo, snapshot?.trackingAuthorizationStatus ?? null);
+    },
+  };
+}
+
+export { buildEligibility as resolveAdSlotEligibility };

--- a/src/lib/ads/index.ts
+++ b/src/lib/ads/index.ts
@@ -1,0 +1,2 @@
+export { DEFAULT_ADS_RELEASE_FLAG, createAdService, resolveAdSlotEligibility } from './ad-service';
+export { resolveAdRequestConfiguration } from './ad-request-configuration';

--- a/src/lib/ads/ios-tracking.ios.ts
+++ b/src/lib/ads/ios-tracking.ios.ts
@@ -1,0 +1,19 @@
+import {
+  PermissionStatus,
+  getTrackingPermissionsAsync,
+  requestTrackingPermissionsAsync,
+} from 'expo-tracking-transparency';
+
+export type TrackingAuthorizationStatus = PermissionStatus;
+
+export async function requestIosTrackingAuthorization(): Promise<TrackingAuthorizationStatus> {
+  const current = await getTrackingPermissionsAsync();
+
+  if (current.status !== PermissionStatus.UNDETERMINED) {
+    return current.status;
+  }
+
+  const requested = await requestTrackingPermissionsAsync();
+
+  return requested.status;
+}

--- a/src/lib/ads/ios-tracking.ts
+++ b/src/lib/ads/ios-tracking.ts
@@ -1,0 +1,5 @@
+export type TrackingAuthorizationStatus = 'unavailable';
+
+export async function requestIosTrackingAuthorization(): Promise<TrackingAuthorizationStatus> {
+  return 'unavailable';
+}


### PR DESCRIPTION
## Summary
- add flag-disabled, consent-gated AdMob boundary with no placements
- pin a Kotlin-compatible AdMob package version for Expo SDK 57
- support an iOS simulator no-op path using the public test App ID, documented for future maintainers

## Validation
- npm run test
- npm run typecheck
- npm run lint
- Android development build
- iOS simulator development build

## Notes
- Expo Doctor patch-version mismatch is a known, deferred baseline issue.